### PR TITLE
Cleanup kafka test server class, refactor @BeforeClass and @AfterClass 

### DIFF
--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1364,7 +1364,7 @@ public class DynamicSpoutTest {
 
         // DynamicSpout config items
         config.put(SpoutConfig.RETRY_MANAGER_CLASS, NeverRetryManager.class.getName());
-        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList("localhost:" + kafkaTestServer.getZkServer().getPort()));
+        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(kafkaTestServer.getKafkaConnectString()));
         config.put(SpoutConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
 
         // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -29,12 +29,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
+import com.salesforce.storm.spout.dynamic.utils.SharedKafkaTestResource;
 import com.salesforce.storm.spout.sideline.SidelineSpout;
 import com.salesforce.storm.spout.sideline.filter.StaticMessageFilter;
 import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
 import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
 import com.salesforce.storm.spout.dynamic.kafka.Consumer;
-import com.salesforce.storm.spout.dynamic.kafka.KafkaTestServer;
+import com.salesforce.storm.spout.dynamic.utils.KafkaTestServer;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
 import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
@@ -58,9 +59,8 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.utils.Utils;
 import org.apache.zookeeper.KeeperException;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -93,22 +93,16 @@ public class DynamicSpoutTest {
     // For logging within the test.
     private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
 
-    // Our internal Kafka and Zookeeper Server, used to test against.
-    private static KafkaTestServer kafkaTestServer;
-
-    // Gets set to our randomly generated namespace created for the test.
-    private String topicName;
+    /**
+     * Create shared kafka test server.
+     */
+    @ClassRule
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
 
     /**
-     * Here we stand up an internal test kafka and zookeeper service.
-     * Once for all methods in this class.
+     * We generate a unique topic name for every test case.
      */
-    @BeforeClass
-    public static void setupKafkaServer() throws Exception {
-        // Setup kafka test server
-        kafkaTestServer = new KafkaTestServer();
-        kafkaTestServer.start();
-    }
+    private String topicName;
 
     /**
      * This happens once before every test method.
@@ -120,24 +114,7 @@ public class DynamicSpoutTest {
         topicName = DynamicSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
 
         // Create namespace
-        kafkaTestServer.createTopic(topicName);
-    }
-
-    /**
-     * Here we shut down the internal test kafka and zookeeper services.
-     */
-    @AfterClass
-    public static void destroyKafkaServer() {
-        // Close out kafka test server if needed
-        if (kafkaTestServer == null) {
-            return;
-        }
-        try {
-            kafkaTestServer.shutdown();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        kafkaTestServer = null;
+        getKafkaTestServer().createTopic(topicName);
     }
 
     @Rule
@@ -815,7 +792,7 @@ public class DynamicSpoutTest {
 
         // Create a namespace with 4 partitions
         topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
-        kafkaTestServer.createTopic(topicName, 4);
+        getKafkaTestServer().createTopic(topicName, 4);
 
         // Define some topicPartitions
         final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
@@ -912,7 +889,7 @@ public class DynamicSpoutTest {
 
         // Create a namespace with 4 partitions
         topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
-        kafkaTestServer.createTopic(topicName, 5);
+        getKafkaTestServer().createTopic(topicName, 5);
 
         // Define some topicPartitions
         final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
@@ -1336,7 +1313,7 @@ public class DynamicSpoutTest {
      * helper method to produce records into kafka.
      */
     private List<ProducedKafkaRecord<byte[], byte[]>> produceRecords(int numberOfRecords, int partitionId) {
-        KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(kafkaTestServer);
+        KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
         return kafkaTestUtils.produceRecords(numberOfRecords, topicName, partitionId);
     }
 
@@ -1357,14 +1334,11 @@ public class DynamicSpoutTest {
         config.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
         config.put(KafkaConsumerConfig.KAFKA_TOPIC, topicName);
         config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, consumerIdPrefix);
-        config.put(
-            KafkaConsumerConfig.KAFKA_BROKERS,
-            Lists.newArrayList("localhost:" + kafkaTestServer.getKafkaServer().serverConfig().advertisedPort())
-        );
+        config.put(KafkaConsumerConfig.KAFKA_BROKERS, Lists.newArrayList(getKafkaTestServer().getKafkaConnectString()));
 
         // DynamicSpout config items
         config.put(SpoutConfig.RETRY_MANAGER_CLASS, NeverRetryManager.class.getName());
-        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(kafkaTestServer.getKafkaConnectString()));
+        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
         config.put(SpoutConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
 
         // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
@@ -1406,5 +1380,12 @@ public class DynamicSpoutTest {
                 // Explicitly defined streamId should get used as is.
                 { "SpecialStreamId", "SpecialStreamId" }
         };
+    }
+
+    /**
+     * Simple accessor.
+     */
+    private KafkaTestServer getKafkaTestServer() {
+        return sharedKafkaTestResource.getKafkaTestServer();
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -2647,7 +2647,7 @@ public class ConsumerTest {
 
         // Dynamic Spout config items
         defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_ROOT, "/sideline-spout-test");
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList("localhost:" + kafkaTestServer.getZkServer().getPort()));
+        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(kafkaTestServer.getKafkaConnectString()));
         defaultConfig.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
 
         return SpoutConfig.setDefaults(defaultConfig);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -149,9 +149,7 @@ public class ConsumerTest {
         final ConsumerPeerContext consumerPeerContext = getDefaultConsumerCohortDefinition();
 
         // Define expected kafka brokers
-        final String expectedKafkaBrokers =
-            getKafkaTestServer().getKafkaServer().serverConfig().advertisedHostName() + ":"
-            + getKafkaTestServer().getKafkaServer().serverConfig().advertisedPort();
+        final String expectedKafkaBrokers = getKafkaTestServer().getKafkaConnectString();
 
         // Call constructor
         final Consumer consumer = new Consumer();
@@ -2620,8 +2618,7 @@ public class ConsumerTest {
         // Kafka Consumer config items
         defaultConfig.put(
             KafkaConsumerConfig.KAFKA_BROKERS,
-            Lists.newArrayList(getKafkaTestServer().getKafkaServer().serverConfig().advertisedHostName()
-            + ":" + getKafkaTestServer().getKafkaServer().serverConfig().advertisedPort())
+            Lists.newArrayList(getKafkaTestServer().getKafkaConnectString())
         );
         defaultConfig.put(KafkaConsumerConfig.KAFKA_TOPIC, topicName);
         defaultConfig.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, "TestPrefix");
@@ -2629,7 +2626,7 @@ public class ConsumerTest {
 
         // Dynamic Spout config items
         defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_ROOT, "/sideline-spout-test");
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getKafkaConnectString()));
+        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
         defaultConfig.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
 
         return SpoutConfig.setDefaults(defaultConfig);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/KafkaTestServer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/KafkaTestServer.java
@@ -28,9 +28,6 @@ package com.salesforce.storm.spout.dynamic.kafka;
 import com.google.common.collect.Maps;
 import kafka.admin.AdminUtils;
 import kafka.admin.RackAwareMode;
-import kafka.consumer.Consumer;
-import kafka.consumer.ConsumerConfig;
-import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
 import kafka.utils.ZKStringSerializer$;
@@ -40,12 +37,6 @@ import org.apache.curator.test.InstanceSpec;
 import org.apache.curator.test.TestingServer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Map;
@@ -59,43 +50,59 @@ import java.util.Properties;
  */
 public class KafkaTestServer implements AutoCloseable {
 
-    private static final Logger logger = LoggerFactory.getLogger(KafkaTestServer.class);
     private TestingServer zkServer;
     private KafkaServerStartable kafka;
 
-    public TestingServer getZkServer() {
+    /**
+     * @return Internal Zookeeper Server.
+     */
+    public TestingServer getZookeeperServer() {
         return this.zkServer;
     }
 
+    /**
+     * @return Internal Kafka Server.
+     */
     public KafkaServerStartable getKafkaServer() {
         return this.kafka;
     }
 
     /**
+     * @return The proper connect string to use for Kafka.
+     */
+    public String getKafkaConnectString() {
+        return "127.0.0.1:" + getKafkaServer().serverConfig().advertisedPort();
+    }
+
+    /**
      * Creates and starts ZooKeeper and Kafka server instances.
-     * @throws Exception Something went wrong.
      */
     public void start() throws Exception {
-        InstanceSpec zkInstanceSpec = new InstanceSpec(null, 21811, -1, -1, true, -1, -1, 1000);
+        // Start zookeeper
+        final InstanceSpec zkInstanceSpec = new InstanceSpec(null, -1, -1, -1, true, -1, -1, 1000);
         zkServer = new TestingServer(zkInstanceSpec, true);
-        String connectionString = getZkServer().getConnectString();
+        final String zkConnectionString = getZookeeperServer().getConnectString();
 
-        File logDir = new File("/tmp/kafka-logs-" + Double.toHexString(Math.random()));
+        // Create temp path to store logs
+        final File logDir = new File("/tmp/kafka-logs-" + Double.toHexString(Math.random()));
         logDir.deleteOnExit();
-        String kafkaPort = String.valueOf(InstanceSpec.getRandomPort());
 
-        Properties properties = new Properties();
-        properties.setProperty("zookeeper.connect", connectionString);
-        properties.setProperty("port", kafkaPort);
-        properties.setProperty("log.dir", logDir.getAbsolutePath());
-        properties.setProperty("host.name", "127.0.0.1");
-        properties.setProperty("advertised.host.name", "127.0.0.1");
-        properties.setProperty("advertised.port", kafkaPort);
-        properties.setProperty("auto.create.topics.enable", "true");
-        properties.setProperty("zookeeper.session.timeout.ms", "30000");
-        properties.setProperty("broker.id", "1");
+        // Determine what port to run kafka on
+        final String kafkaPort = String.valueOf(InstanceSpec.getRandomPort());
 
-        KafkaConfig config = new KafkaConfig(properties);
+        // Build properties
+        Properties kafkaProperties = new Properties();
+        kafkaProperties.setProperty("zookeeper.connect", zkConnectionString);
+        kafkaProperties.setProperty("port", kafkaPort);
+        kafkaProperties.setProperty("log.dir", logDir.getAbsolutePath());
+        kafkaProperties.setProperty("host.name", "127.0.0.1");
+        kafkaProperties.setProperty("advertised.host.name", "127.0.0.1");
+        kafkaProperties.setProperty("advertised.port", kafkaPort);
+        kafkaProperties.setProperty("auto.create.topics.enable", "true");
+        kafkaProperties.setProperty("zookeeper.session.timeout.ms", "30000");
+        kafkaProperties.setProperty("broker.id", "1");
+
+        final KafkaConfig config = new KafkaConfig(kafkaProperties);
         kafka = new KafkaServerStartable(config);
         getKafkaServer().startup();
     }
@@ -105,7 +112,7 @@ public class KafkaTestServer implements AutoCloseable {
      * Will create a namespace with exactly 1 partition.
      * @param topicName - the namespace name to create.
      */
-    public void createTopic(String topicName) {
+    public void createTopic(final String topicName) {
         createTopic(topicName, 1);
     }
 
@@ -115,16 +122,16 @@ public class KafkaTestServer implements AutoCloseable {
      * @param partitions - the number of partitions to create.
      */
     public void createTopic(final String topicName, final int partitions) {
-        int sessionTimeoutInMs = 10000;
-        int connectionTimeoutInMs = 10000;
+        final int sessionTimeoutInMs = 10000;
+        final int connectionTimeoutInMs = 10000;
 
-        /**
+        /*
          * Note: You must initialize the ZkClient with ZKStringSerializer. If you don't then createTopic()
          * will only seem to work (it will return without error). The namespace will exist only in ZooKeeper
          * and will be returned when listing topics, but Kafka itself does not create the namespace.
          */
         ZkClient zkClient = new ZkClient(
-            getZkServer().getConnectString(),
+            getZookeeperServer().getConnectString(),
             sessionTimeoutInMs,
             connectionTimeoutInMs,
             ZKStringSerializer$.MODULE$
@@ -142,7 +149,6 @@ public class KafkaTestServer implements AutoCloseable {
     /**
      * Shuts down the ZooKeeper and Kafka server instances. This *must* be called before the integration
      * test completes in order to clean up any running processes and data that was created.
-     * @throws Exception Something went wrong.
      */
     public void shutdown() throws Exception {
         close();
@@ -151,20 +157,10 @@ public class KafkaTestServer implements AutoCloseable {
     /**
      * Creates a kafka producer that is connected to our test server.
      */
-    public KafkaProducer getKafkaProducer() {
-        return getKafkaProducer(
-            StringSerializer.class.getName(),
-            ByteArraySerializer.class.getName()
-        );
-    }
-
-    /**
-     * Creates a kafka producer that is connected to our test server.
-     */
-    public KafkaProducer getKafkaProducer(String keySerializer, String valueSerializer) {
+    public KafkaProducer getKafkaProducer(final String keySerializer, final String valueSerializer) {
         // Create producer
-        Map<String, Object> kafkaProducerConfig = Maps.newHashMap();
-        kafkaProducerConfig.put("bootstrap.servers", "127.0.0.1:" + getKafkaServer().serverConfig().advertisedPort());
+        final Map<String, Object> kafkaProducerConfig = Maps.newHashMap();
+        kafkaProducerConfig.put("bootstrap.servers", getKafkaConnectString());
         kafkaProducerConfig.put("key.serializer", keySerializer);
         kafkaProducerConfig.put("value.serializer", valueSerializer);
         kafkaProducerConfig.put("batch.size", 0);
@@ -174,46 +170,33 @@ public class KafkaTestServer implements AutoCloseable {
     }
 
     /**
-     * Old 0.8.2.x consumer.
+     * Return Kafka Consumer configured to consume from internal Kafka Server.
+     * @param keyDeserializer which deserializer to use for key
+     * @param valueDeserializer which deserializer to use for value
      */
-    public ConsumerConnector getKafkaConsumerConnector() {
-        Properties consumerProperties = new Properties();
-        consumerProperties.put("zookeeper.connect", getZkServer().getConnectString());
-        consumerProperties.put("group.id", "test-group");
-
-        // Start from the head of the namespace by default
-        consumerProperties.put("auto.offset.reset", "smallest");
-
-        // Don't commit offsets anywhere for our consumerId
-        consumerProperties.put("auto.commit.enable", "false");
-        logger.info("Consumer properties {}", consumerProperties);
-        return Consumer.createJavaConsumerConnector(new ConsumerConfig(consumerProperties));
-    }
-
-    /**
-     * Depending on your version of Kafka, this may or may not be implemented.
-     * 0.8.2.2 this does NOT work!.
-     * @return Kafka consumer instance.
-     */
-    public KafkaConsumer getKafkaConsumer() {
+    public KafkaConsumer getKafkaConsumer(final String keyDeserializer, final String valueDeserializer) {
         Map<String, Object> kafkaConsumerConfig = Maps.newHashMap();
-        kafkaConsumerConfig.put("bootstrap.servers", "127.0.0.1:" + getKafkaServer().serverConfig().advertisedPort());
+        kafkaConsumerConfig.put("bootstrap.servers", getKafkaConnectString());
         kafkaConsumerConfig.put("group.id", "test-consumer-id");
-        kafkaConsumerConfig.put("key.deserializer", StringDeserializer.class.getName());
-        kafkaConsumerConfig.put("value.deserializer", ByteArrayDeserializer.class.getName());
+        kafkaConsumerConfig.put("key.deserializer", keyDeserializer);
+        kafkaConsumerConfig.put("value.deserializer", valueDeserializer);
         kafkaConsumerConfig.put("partition.assignment.strategy", "org.apache.kafka.clients.consumer.RoundRobinAssignor");
 
         return new KafkaConsumer(kafkaConsumerConfig);
     }
 
+    /**
+     * Closes the internal servers. Failing to call this at the end of your tests will likely
+     * result in leaking instances.
+     */
     @Override
     public void close() throws Exception {
         if (getKafkaServer() != null) {
             getKafkaServer().shutdown();
             kafka = null;
         }
-        if (getZkServer() != null) {
-            getZkServer().close();
+        if (getZookeeperServer() != null) {
+            getZookeeperServer().close();
             zkServer = null;
         }
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/KafkaTestServerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/KafkaTestServerTest.java
@@ -25,18 +25,32 @@
 
 package com.salesforce.storm.spout.dynamic.kafka;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import kafka.consumer.ConsumerIterator;
 import kafka.consumer.KafkaStream;
 import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.message.MessageAndMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -44,72 +58,112 @@ import java.util.concurrent.Future;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests producer and old style consumer.
+ * Test of KafkaTestServer.
+ *
+ * This also serves as an example of how to use this library!
  */
 public class KafkaTestServerTest {
     private static final Logger logger = LoggerFactory.getLogger(KafkaTestServerTest.class);
 
     /**
-     * Tests producer and old style consumer.
+     * We have a single embedded kafka server that runs for every test within this class.
+     *
+     * It's automatically started before any methods are run via the @BeforeClass annotation.
+     * It's automatically stopped after all of the tests are completed via the @AfterClass annotation.
+     */
+    private KafkaTestServer kafkaTestServer;
+
+    /**
+     * Before every test, we generate a random topic name and create it within the embedded kafka server.
+     * Each test can then be segmented run any tests against its own topic.
+     */
+    private String topicName;
+
+    /**
+     * This happens once before every test method.
+     * Create a new empty namespace with randomly generated name.
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        // Setup kafka test server
+        kafkaTestServer = new KafkaTestServer();
+        kafkaTestServer.start();
+
+        // Generate topic name
+        topicName = getClass().getSimpleName() + Clock.systemUTC().millis();
+
+        // Create topic with a single partition,
+        // NOTE: This will create partition id 0, because partitions are indexed at 0 :)
+        kafkaTestServer.createTopic(topicName, 1);
+    }
+
+    /**
+     * Here we shut down the internal test kafka and zookeeper services.
+     */
+    @After
+    public void destroyKafkaServer() {
+        // Close out kafka test server if needed
+        if (kafkaTestServer == null) {
+            return;
+        }
+
+        try {
+            kafkaTestServer.shutdown();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+        kafkaTestServer = null;
+    }
+
+    /**
+     * Test that KafkaServer works as expected!
+     *
+     * This also serves as a decent example of how to use the producer and consumer.
      */
     @Test
     public void testProducerAndConsumer() throws Exception {
-        final String topicName = "dummy-namespace";
         final int partitionId = 0;
-
-        // Start server
-        KafkaTestServer server = new KafkaTestServer();
-        server.start();
-
-        // Create a dummy namespace
-        server.createTopic(topicName);
 
         // Define our message
         final String expectedKey = "my-key";
         final String expectedValue = "my test message";
 
-        // Publish a msg
-        ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(
-            topicName,
-            partitionId,
-            expectedKey,
-            expectedValue.getBytes("utf8")
-        );
-        KafkaProducer<String, byte[]> producer = server.getKafkaProducer();
-        Future<RecordMetadata> future = producer.send(producerRecord);
+        // Define the record we want to produce
+        ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topicName, partitionId, expectedKey, expectedValue);
+
+        // Create a new producer
+        KafkaProducer<String, String> producer = kafkaTestServer.getKafkaProducer(StringSerializer.class.getName(), StringSerializer.class.getName());
+
+        // Produce it & wait for it to complete.
+        final RecordMetadata recordMetadata = producer.send(producerRecord).get();
         producer.flush();
-        while (!future.isDone()) {
-            Thread.sleep(500L);
-        }
         logger.info("Produce completed");
+
+        // Close producer!
         producer.close();
 
-
-        Map<String, Integer> topicCountMap = Maps.newHashMap();
-        topicCountMap.put(topicName, 1);
-
-        // Consume message
-        logger.info("Starting to get Consumer...");
-        ConsumerConnector consumer = server.getKafkaConsumerConnector();
-        Map<String, List<KafkaStream<byte[], byte[]>>> consumerMap = consumer.createMessageStreams(topicCountMap);
-
-        KafkaStream<byte[], byte[]> stream =  consumerMap.get(topicName).get(0);
-        ConsumerIterator<byte[], byte[]> it = stream.iterator();
-        for (int x = 0; x < 5; x++) {
-            if (it.hasNext()) {
-                break;
-            }
-            Thread.sleep(1000L);
+        KafkaConsumer<String, String> kafkaConsumer = kafkaTestServer.getKafkaConsumer(StringDeserializer.class.getName(), StringDeserializer.class.getName());
+        List<TopicPartition> topicPartitionList = Lists.newArrayList();
+        for (PartitionInfo partitionInfo: kafkaConsumer.partitionsFor(topicName)) {
+            topicPartitionList.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
         }
-        MessageAndMetadata<byte[], byte[]> message = it.next();
-        String foundMessage = new String(message.message(), "utf8");
-        String foundKey = new String(message.key(), "utf8");
+        kafkaConsumer.assign(topicPartitionList);
+        kafkaConsumer.seekToBeginning(topicPartitionList);
 
-        assertEquals("Should have message", expectedValue, foundMessage);
-        assertEquals("Should have key", expectedKey, foundKey);
-        consumer.shutdown();
+        // Pull records from kafka, keep polling until we get nothing back
+        ConsumerRecords<String, String> records;
+        do {
+            records = kafkaConsumer.poll(2000L);
+            logger.info("Found {} records in kafka", records.count());
+            for (ConsumerRecord<String, String> record: records) {
+                // Validate
+                assertEquals("Key matches expected", expectedKey, record.key());
+                assertEquals("value matches expected", expectedValue, record.value());
+            }
+        }
+        while (!records.isEmpty());
 
-        // Shutdown server
-        server.shutdown();
+        // close consumer
+        kafkaConsumer.close();
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/utils/KafkaTestServer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/utils/KafkaTestServer.java
@@ -23,7 +23,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.dynamic.kafka;
+package com.salesforce.storm.spout.dynamic.utils;
 
 import com.google.common.collect.Maps;
 import kafka.admin.AdminUtils;
@@ -72,6 +72,13 @@ public class KafkaTestServer implements AutoCloseable {
      */
     public String getKafkaConnectString() {
         return "127.0.0.1:" + getKafkaServer().serverConfig().advertisedPort();
+    }
+
+    /**
+     * @return The proper connect string to use for Zookeeper.
+     */
+    public String getZookeeperConnectString() {
+        return "127.0.0.1:" + getZookeeperServer().getPort();
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/utils/KafkaTestUtils.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/utils/KafkaTestUtils.java
@@ -25,12 +25,11 @@
 
 package com.salesforce.storm.spout.dynamic.utils;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
-import com.salesforce.storm.spout.dynamic.kafka.KafkaTestServer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import com.google.common.base.Charsets;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/com/salesforce/storm/spout/dynamic/utils/SharedKafkaTestResource.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/utils/SharedKafkaTestResource.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.utils;
+
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates and stands up an internal test kafka server to be shared across test cases within the same test class.
+ *
+ * Example within your Test class.
+ *
+ *   &#064;ClassRule
+ *   public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
+ *
+ * Within your test case method:
+ *   sharedKafkaTestResource.getKafkaTestServer()...
+ */
+public class SharedKafkaTestResource extends ExternalResource {
+    private static final Logger logger = LoggerFactory.getLogger(SharedKafkaTestResource.class);
+
+    /**
+     * Our internal Kafka Test Server instance.
+     */
+    private KafkaTestServer kafkaTestServer = null;
+
+    /**
+     * Here we stand up an internal test kafka and zookeeper service.
+     * Once for all tests that use this shared resource.
+     */
+    protected void before() throws Exception {
+        logger.info("Starting kafka test server");
+        if (kafkaTestServer != null) {
+            throw new IllegalStateException("Unknown State!  Kafka Test Server already exists!");
+        }
+        // Setup kafka test server
+        kafkaTestServer = new KafkaTestServer();
+        kafkaTestServer.start();
+    }
+
+    /**
+     * Here we shut down the internal test kafka and zookeeper services.
+     */
+    protected void after() {
+        logger.info("Shutting down kafka test server");
+
+        // Close out kafka test server if needed
+        if (kafkaTestServer == null) {
+            return;
+        }
+        try {
+            kafkaTestServer.shutdown();
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+        kafkaTestServer = null;
+    }
+
+    /**
+     * @return Shared Kafka Test server instance.
+     */
+    public KafkaTestServer getKafkaTestServer() {
+        return kafkaTestServer;
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/utils/SharedZookeeperTestResource.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/utils/SharedZookeeperTestResource.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.utils;
+
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Creates and stands up an internal test Zookeeper server to be shared across test cases within the same test class.
+ *
+ * Example within your Test class.
+ *
+ *   &#064;ClassRule
+ *   public static final SharedZookeeperTestResource sharedZookeeperTestResource = new sharedZookeeperTestResource();
+ *
+ * Within your test case method:
+ *   sharedZookeeperTestResource.getZookeeperTestServer()...
+ */
+public class SharedZookeeperTestResource extends ExternalResource {
+    private static final Logger logger = LoggerFactory.getLogger(SharedZookeeperTestResource.class);
+
+    /**
+     * Our internal Zookeeper test server instance.
+     */
+    private TestingServer zookeeperTestServer = null;
+
+    /**
+     * Here we stand up an internal test zookeeper service.
+     * Once for all tests that use this shared resource.
+     */
+    protected void before() throws Exception {
+        logger.info("Starting Zookeeper test server");
+        if (zookeeperTestServer != null) {
+            throw new IllegalStateException("Unknown State! Zookeeper test server already exists!");
+        }
+        // Setup zookeeper test server
+        final InstanceSpec zkInstanceSpec = new InstanceSpec(null, -1, -1, -1, true, -1, -1, 1000);
+        zookeeperTestServer = new TestingServer(zkInstanceSpec, true);
+    }
+
+    /**
+     * Here we shut down the internal test zookeeper service.
+     */
+    protected void after() {
+        logger.info("Shutting down zookeeper test server");
+
+        // Close out zookeeper test server if needed
+        if (zookeeperTestServer == null) {
+            return;
+        }
+        try {
+            zookeeperTestServer.stop();
+            zookeeperTestServer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        zookeeperTestServer = null;
+    }
+
+    /**
+     * @return Shared Zookeeper test server instance.
+     */
+    public TestingServer getZookeeperTestServer() {
+        return zookeeperTestServer;
+    }
+}


### PR DESCRIPTION
General clean up of Kafka Test Server class, removed some dead methods, added some utility methods to get the Kafka and Zookeeper connection strings.

Also refactored BeforeClass and AfterClass usages in tests around standing up internal kafka/zookeeper servers.  This logic got moved into a re-usable ClassRule resource to remove code duplication and standardize it.