### PR TITLE
Handle startup race condition in SidelineSpout Handler

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -170,8 +170,8 @@ public class DynamicSpout extends BaseRichSpout {
             messageBuffer
         );
 
-        // Call open on coordinator.
-        getCoordinator().open(getSpoutConfig());
+        // Call open on coordinator, avoiding getter
+        coordinator.open(getSpoutConfig());
 
         // For emit metrics
         emitCountMetrics = Maps.newHashMap();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -171,7 +171,7 @@ public class DynamicSpout extends BaseRichSpout {
         );
 
         // Call open on coordinator.
-        coordinator.open(getSpoutConfig());
+        getCoordinator().open(getSpoutConfig());
 
         // For emit metrics
         emitCountMetrics = Maps.newHashMap();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/SpoutCoordinator.java
@@ -155,6 +155,8 @@ public class SpoutCoordinator {
         this.topologyConfig = Tools.immutableCopy(topologyConfig);
 
         // Create a countdown latch
+        // TODO I think this latch is now not needed, as at open time, nothing can be in the queue yet.
+        // TODO we should remove it as its just extra clutter being passed all over.
         final CountDownLatch latch = new CountDownLatch(getNewSpoutQueue().size());
 
         // Create new single threaded executor.

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -127,9 +127,6 @@ public class SidelineSpoutHandler implements SpoutHandler {
             null
         );
 
-        // Our main firehose spout instance.
-        spout.addVirtualSpout(fireHoseSpout);
-
         final String topic = (String) getSpoutConfig().get(KafkaConsumerConfig.KAFKA_TOPIC);
 
         final List<SidelineRequestIdentifier> existingRequestIds = spout.getPersistenceAdapter().listSidelineRequests();
@@ -186,6 +183,11 @@ public class SidelineSpoutHandler implements SpoutHandler {
         for (final SidelineTrigger sidelineTrigger : sidelineTriggers) {
             sidelineTrigger.open(getSpoutConfig());
         }
+
+        // After altering the filter chain is complete, lets NOW start the fire hose
+        // This keeps a race condition where the fire hose could start consuming before filter chain
+        // steps get added.
+        spout.addVirtualSpout(fireHoseSpout);
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1220,7 +1220,7 @@ public class DynamicSpoutTest {
                 // Lets log it
                 logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
             }
-            assertEquals("No new tuple emits on iteration " + (x+1), originalSize, collector.getEmissions().size());
+            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
         }
     }
 

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1212,8 +1212,15 @@ public class DynamicSpoutTest {
         // Try a certain number of times
         final int originalSize = collector.getEmissions().size();
         for (int x = 0; x < numberOfAttempts; x++) {
+            // Call next Tuple
             spout.nextTuple();
-            assertEquals("No new tuple emits", originalSize, collector.getEmissions().size());
+
+            // If we get an unexpected emission
+            if (originalSize != collector.getEmissions().size()) {
+                // Lets log it
+                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
+            }
+            assertEquals("No new tuple emits on iteration " + (x+1), originalSize, collector.getEmissions().size());
         }
     }
 


### PR DESCRIPTION
@stanlemon Prior to splitting Sideline stuff out from DynamicSpout, we used a latch to synchronize all of the virtual spouts to start at the same time in the SpoutCoordinator.open() call on startup.

After the refactor, SpoutCoordinator.open() gets called prior to SidelineSpoutHandler.onSpoutOpen() (where virtual spouts get added) so we no longer have a guarantee around the virtual spouts starting at the same time. Once SidelineSpoutHandler starts adding VirtualSpouts they start immediately and begin consuming.  
(Relevant code in DynamicSpout.open(): https://github.com/salesforce/storm-dynamic-spout/blob/master/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java#L165-L186 )

We had a race condition that showed up in DynamicSpoutTest::testResumingSpoutWhileSidelinedVirtualSpoutIsActive() that showed this.  Basically before the Firehose got its filter chain updated while resuming any active sidelines, it had already started consuming.

For some reason this tended to fail/flap more often on the kafka011 branches, but I believe if we adjust the order of adding virtual spouts on start should resolve the issue.  Please sanity check this?