### PR TITLE
Add ability for VirtualSpouts to report errors back to Storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Improvements
 - [PR-14](https://github.com/salesforce/storm-dynamic-spout/pull/14) Update Kafka dependencies to 0.11.0.1
 - [PR-15](https://github.com/salesforce/storm-dynamic-spout/pull/15) Update Storm dependencies to 1.1.1
+- [PR-24](https://github.com/salesforce/storm-dynamic-spout/pull/24) Add ability for errors to be reported up to the Storm web UI.
 
 ### Bug Fixes
 - [PR-16](https://github.com/salesforce/storm-dynamic-spout/pull/16) *Kafka Consumer* Improved handling of Out Of Range exceptions

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * DynamicSpout's contain other virtualized spouts, and provide mechanisms for interacting with the spout life cycle
@@ -205,6 +206,11 @@ public class DynamicSpout extends BaseRichSpout {
 
         // Update emit count metric for VirtualSpout this tuple originated from
         getMetricsRecorder().count(VirtualSpout.class, message.getMessageId().getSrcVirtualSpoutId() + ".emit", 1);
+
+        // Report any errors
+        getCoordinator()
+            .getErrors()
+            .ifPresent(throwable -> getOutputCollector().reportError(throwable));
 
         // Everything below is temporary emit metrics for debugging.
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/SpoutCoordinator.java
@@ -87,7 +87,7 @@ public class SpoutCoordinator {
     private final Map<VirtualSpoutIdentifier, Queue<MessageId>> failedTuplesQueue = new ConcurrentHashMap<>();
 
     /**
-     * Buffer by spout consumer id of errors to be reported.
+     * Buffer for errors that need to be reported.
      */
     private final Queue<Throwable> reportedErrorsQueue = new ConcurrentLinkedQueue<>();
 
@@ -201,7 +201,7 @@ public class SpoutCoordinator {
      */
     private void startSpoutMonitor() {
         CompletableFuture.runAsync(spoutMonitor, getExecutor()).exceptionally((exception) -> {
-            // This fires if SpoutMonitor dies unexpectedly by throwing an exception.
+            // This fires if SpoutMonitor dies because it threw an unhandled exception.
 
             // On errors, we need to restart it.  We throttle restarts @ 10 seconds to prevent thrashing.
             logger.error("Spout monitor died unnaturally.  Will restart after 10 seconds. {}", exception.getMessage(), exception);
@@ -244,14 +244,14 @@ public class SpoutCoordinator {
     }
 
     /**
-     * @return - Returns the next available Message to be emitted into the topology.
+     * @return Returns the next available Message to be emitted into the topology.
      */
     public Message nextMessage() {
         return getMessageBuffer().poll();
     }
 
     /**
-     * @return - Returns any errors that should be reported up to the topology.
+     * @return Returns any errors that should be reported up to the topology.
      */
     public Optional<Throwable> getErrors() {
         // Poll is non-blocking.
@@ -347,14 +347,14 @@ public class SpoutCoordinator {
     }
 
     /**
-     * @return - the maximum amount of time we'll wait for spouts to terminate before forcing them to stop, in milliseconds.
+     * @return The maximum amount of time we'll wait for spouts to terminate before forcing them to stop, in milliseconds.
      */
     private long getMaxTerminationWaitTimeMs() {
         return ((Number) getTopologyConfig().get(SpoutConfig.MAX_SPOUT_SHUTDOWN_TIME_MS)).longValue();
     }
 
     /**
-     * @return - our internal executor service.
+     * @return Our internal executor service.
      */
     ExecutorService getExecutor() {
         return executor;

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -421,7 +421,7 @@ public class VirtualSpout implements DelegateSpout {
         final MessageId messageId;
         try {
             messageId = (MessageId) msgId;
-        } catch (ClassCastException e) {
+        } catch (final ClassCastException e) {
             throw new IllegalArgumentException("Invalid msgId object type passed " + msgId.getClass());
         }
         ackTimeBuckets.put("MessageId", ackTimeBuckets.get("MessageId") + (System.currentTimeMillis() - start));
@@ -466,7 +466,7 @@ public class VirtualSpout implements DelegateSpout {
         final MessageId messageId;
         try {
             messageId = (MessageId) msgId;
-        } catch (ClassCastException e) {
+        } catch (final ClassCastException e) {
             throw new IllegalArgumentException("Invalid msgId object type passed " + msgId.getClass());
         }
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
@@ -90,6 +90,11 @@ public class SpoutMonitor implements Runnable {
     private final Map<VirtualSpoutIdentifier,Queue<MessageId>> failedTuplesQueue;
 
     /**
+     * This buffer/queue holds errors that should be reported up to the topology.
+     */
+    private final Queue<Throwable> reportedErrorsQueue;
+
+    /**
      * This latch allows the SpoutCoordinator to block on start up until its initial
      * set of VirtualSpout instances have started.
      */
@@ -109,14 +114,13 @@ public class SpoutMonitor implements Runnable {
      * Metrics Recorder implementation for collecting metrics.
      */
     private final MetricsRecorder metricsRecorder;
-    
+
     /**
      * Calculates progress of {@link VirtualSpout} instances.
      */
     private SpoutPartitionProgressMonitor spoutPartitionProgressMonitor;
 
     private final Map<VirtualSpoutIdentifier, SpoutRunner> spoutRunners = new ConcurrentHashMap<>();
-    private final Map<VirtualSpoutIdentifier, CompletableFuture> spoutThreads = new ConcurrentHashMap<>();
 
     /**
      * Flag used to determine if we should stop running or not.
@@ -134,6 +138,7 @@ public class SpoutMonitor implements Runnable {
      * @param tupleOutputQueue Queue for pushing out Tuples to the topology.
      * @param ackedTuplesQueue Queue for incoming Tuples that need to be acked.
      * @param failedTuplesQueue Queue for incoming Tuples that need to be failed.
+     * @param reportedErrorsQueue Queue for any errors that should be reported to the topology.
      * @param latch Latch to allow startup synchronization.
      * @param clock Which clock instance to use, allows injecting a mock clock.
      * @param topologyConfig Storm topology config.
@@ -144,6 +149,7 @@ public class SpoutMonitor implements Runnable {
         final MessageBuffer tupleOutputQueue,
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> ackedTuplesQueue,
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> failedTuplesQueue,
+        final Queue<Throwable> reportedErrorsQueue,
         final CountDownLatch latch,
         final Clock clock,
         final Map<String, Object> topologyConfig,
@@ -153,6 +159,7 @@ public class SpoutMonitor implements Runnable {
         this.tupleOutputQueue = tupleOutputQueue;
         this.ackedTuplesQueue = ackedTuplesQueue;
         this.failedTuplesQueue = failedTuplesQueue;
+        this.reportedErrorsQueue = reportedErrorsQueue;
         this.latch = latch;
         this.clock = clock;
         this.topologyConfig = Tools.immutableCopy(topologyConfig);
@@ -186,7 +193,7 @@ public class SpoutMonitor implements Runnable {
     public boolean hasSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
         // Synchronized on new spout queue
         synchronized (newSpoutQueue) {
-            for (DelegateSpout spout : newSpoutQueue) {
+            for (final DelegateSpout spout : newSpoutQueue) {
                 if (spout.getVirtualSpoutId().equals(virtualSpoutIdentifier)) {
                     return true;
                 }
@@ -203,9 +210,6 @@ public class SpoutMonitor implements Runnable {
 
             // Start monitoring loop.
             while (keepRunning()) {
-                // Look for completed tasks
-                watchForCompletedTasks();
-
                 // Look for new VirtualSpouts that need to be started
                 startNewSpoutTasks();
 
@@ -215,15 +219,19 @@ public class SpoutMonitor implements Runnable {
                 // Pause for a period before checking for more spouts
                 try {
                     Thread.sleep(getMonitorThreadIntervalMs());
-                } catch (InterruptedException ex) {
+                } catch (final InterruptedException ex) {
                     logger.warn("Thread interrupted, shutting down...");
                     return;
                 }
             }
             logger.warn("Spout coordinator is ceasing to run due to shutdown request...");
-        } catch (Exception ex) {
-            // TODO: Should we restart the monitor?
-            logger.error("!!!!!! SpoutMonitor threw an exception {}", ex);
+        } catch (final Exception ex) {
+            // We handle restarting spout monitor in the coordinator, which is who monitors this thread.
+            // Lets report the error
+            reportError(ex);
+
+            // And log it.
+            logger.error("!!!!!! SpoutMonitor threw an exception {}", ex.getMessage(), ex);
         }
     }
 
@@ -249,47 +257,38 @@ public class SpoutMonitor implements Runnable {
                     getTopologyConfig()
                 );
 
+                // This maps VirtualSpout Ids to SpoutRunner Instances.
+                // Really we only use this to keep track of which VirtualSpoutIds we have running.
                 spoutRunners.put(spout.getVirtualSpoutId(), spoutRunner);
 
                 // Run as a CompletableFuture
-                final CompletableFuture completableFuture = CompletableFuture.runAsync(spoutRunner, getExecutor());
-                // If the spout runner throws an exception log some info about it so we can dig into handling it more appropriately
-                completableFuture.exceptionally((ex) -> {
-                    logger.error(
-                        "An exception has occurred in the SpoutRunner for {} {}",
-                        virtualSpoutIdentifier,
-                        ex
-                    );
+                final CompletableFuture<Void> completableFuture = CompletableFuture.runAsync(spoutRunner, getExecutor());
+
+                // Handle when this spout completes.
+                // It can either complete successfully, or via some kind of error, we'll handle both here.
+                completableFuture.handle((final Void result, final Throwable exception) -> {
+                    // If we got passed an exception
+                    if (exception != null) {
+                        // We failed via some kind of error, lets report it
+                        reportError(exception);
+
+                        // Log error
+                        logger.error(
+                            "An exception has occurred in the SpoutRunner for {} {}",
+                            virtualSpoutIdentifier,
+                            exception
+                        );
+                    } else {
+                        // Log that we completed successfully.
+                        logger.info("{} seems to have finished, cleaning up", virtualSpoutIdentifier);
+                    }
+
+                    // And cleanup, Remove from spoutInstances
+                    spoutRunners.remove(virtualSpoutIdentifier);
+
+                    // We have no value to return
                     return null;
                 });
-                spoutThreads.put(spout.getVirtualSpoutId(), completableFuture);
-            }
-        }
-    }
-
-    /**
-     * Look for any tasks that have finished running and handle them appropriately.
-     */
-    private void watchForCompletedTasks() {
-        // Cleanup loop
-        for (Map.Entry<VirtualSpoutIdentifier, CompletableFuture> entry: spoutThreads.entrySet()) {
-            final VirtualSpoutIdentifier virtualSpoutId = entry.getKey();
-            final CompletableFuture future = entry.getValue();
-
-            if (future.isDone()) {
-                if (future.isCompletedExceptionally()) {
-                    // This threw an exception.  We need to handle the error case.
-                    // TODO: Handle errors here.
-                    logger.error("{} seems to have errored", virtualSpoutId);
-                } else {
-                    // Successfully finished?
-                    logger.info("{} seems to have finished, cleaning up", virtualSpoutId);
-                }
-
-                // Remove from spoutThreads?
-                // Remove from spoutInstances?
-                spoutRunners.remove(virtualSpoutId);
-                spoutThreads.remove(virtualSpoutId);
             }
         }
     }
@@ -324,7 +323,7 @@ public class SpoutMonitor implements Runnable {
             executor.getCompletedTaskCount(),
             executor.getTaskCount()
         );
-        logger.info("MessageBuffer size: {}, Running VirtualSpoutIds: {}", tupleOutputQueue.size(), spoutThreads.keySet());
+        logger.info("MessageBuffer size: {}, Running VirtualSpoutIds: {}", tupleOutputQueue.size(), spoutRunners.keySet());
 
         // Report to metrics record
         getMetricsRecorder().assignValue(getClass(), "bufferSize", tupleOutputQueue.size());
@@ -357,8 +356,12 @@ public class SpoutMonitor implements Runnable {
                     spout.getVirtualSpoutId() + ".number_filters_applied", spout.getNumberOfFiltersApplied()
                 );
             }
-        } catch (Throwable t) {
-            logger.error("Caught exception during status checks {}", t.getMessage(), t);
+        } catch (final Throwable throwable) {
+            // report the error up.
+            reportError(throwable);
+
+            // Log the exception
+            logger.error("Caught exception during status checks {}", throwable.getMessage(), throwable);
             spoutPartitionProgressMonitor = null;
         }
     }
@@ -384,7 +387,7 @@ public class SpoutMonitor implements Runnable {
         }
 
         // Loop through our runners and request stop on each
-        for (SpoutRunner spoutRunner : spoutRunners.values()) {
+        for (final SpoutRunner spoutRunner : spoutRunners.values()) {
             spoutRunner.requestStop();
         }
 
@@ -392,8 +395,8 @@ public class SpoutMonitor implements Runnable {
         try {
             logger.info("Waiting a maximum of {} ms for thread pool to shutdown", getMaxTerminationWaitTimeMs());
             executor.awaitTermination(getMaxTerminationWaitTimeMs(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException ex) {
-            logger.error("Interrupted while stopping: {}", ex);
+        } catch (final InterruptedException ex) {
+            logger.error("Interrupted while stopping: {}", ex.getMessage(), ex);
         }
 
         // If we didn't shut down cleanly
@@ -405,7 +408,6 @@ public class SpoutMonitor implements Runnable {
 
         // Clear our our internal state.
         spoutRunners.clear();
-        spoutThreads.clear();
     }
 
     /**
@@ -461,6 +463,15 @@ public class SpoutMonitor implements Runnable {
             spoutPartitionProgressMonitor = new SpoutPartitionProgressMonitor(getMetricsRecorder());
         }
         return spoutPartitionProgressMonitor;
+    }
+
+    /**
+     * Adds an error to the reported errors queue.  These will get pushed up and reported
+     * to the topology.
+     * @param throwable The error to be reported.
+     */
+    private void reportError(final Throwable throwable) {
+        reportedErrorsQueue.add(throwable);
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
@@ -232,7 +232,7 @@ public class SpoutMonitor implements Runnable {
             reportError(ex);
 
             // Log it.
-            logger.error("!!!!!! SpoutMonitor threw an exception {}", ex.getMessage(), ex);
+            logger.error("SpoutMonitor threw an exception {}", ex.getMessage(), ex);
 
             // And bubble it up
             throw ex;

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitor.java
@@ -230,8 +230,11 @@ public class SpoutMonitor implements Runnable {
             // Lets report the error
             reportError(ex);
 
-            // And log it.
+            // Log it.
             logger.error("!!!!!! SpoutMonitor threw an exception {}", ex.getMessage(), ex);
+
+            // And bubble it up
+            throw ex;
         }
     }
 
@@ -412,7 +415,7 @@ public class SpoutMonitor implements Runnable {
 
     /**
      * @return - return the number of spout runner instances.
-     *           *note* - it doesn't mean all of these are actually running, some may be queued.
+     *           *note* it doesn't mean all of these are actually running, some may be queued.
      */
     public int getTotalSpouts() {
         return spoutRunners.size();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorFactory.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.coordinator;
+
+import com.salesforce.storm.spout.dynamic.DelegateSpout;
+import com.salesforce.storm.spout.dynamic.MessageId;
+import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
+import com.salesforce.storm.spout.dynamic.buffer.MessageBuffer;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Used to create instances of SpoutMonitor.
+ */
+public class SpoutMonitorFactory {
+
+    /**
+     * Factory method.
+     * @param newSpoutQueue Queue monitored for new Spouts that should be started.
+     * @param tupleOutputQueue Queue for pushing out Tuples to the topology.
+     * @param ackedTuplesQueue Queue for incoming Tuples that need to be acked.
+     * @param failedTuplesQueue Queue for incoming Tuples that need to be failed.
+     * @param reportedErrorsQueue Queue for any errors that should be reported to the topology.
+     * @param latch Latch to allow startup synchronization.
+     * @param clock Which clock instance to use, allows injecting a mock clock.
+     * @param topologyConfig Storm topology config.
+     * @param metricsRecorder MetricRecorder implementation for recording metrics.
+     * @return new SpoutMonitor instance.
+     */
+    public SpoutMonitor create(
+        final Queue<DelegateSpout> newSpoutQueue,
+        final MessageBuffer tupleOutputQueue,
+        final Map<VirtualSpoutIdentifier, Queue<MessageId>> ackedTuplesQueue,
+        final Map<VirtualSpoutIdentifier, Queue<MessageId>> failedTuplesQueue,
+        final Queue<Throwable> reportedErrorsQueue,
+        final CountDownLatch latch,
+        final Clock clock,
+        final Map<String, Object> topologyConfig,
+        final MetricsRecorder metricsRecorder) {
+
+        // Create instance.
+        return new SpoutMonitor(
+            newSpoutQueue,
+            tupleOutputQueue,
+            ackedTuplesQueue,
+            failedTuplesQueue,
+            reportedErrorsQueue,
+            latch,
+            clock,
+            topologyConfig,
+            metricsRecorder
+        );
+    }
+}

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunner.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunner.java
@@ -145,6 +145,7 @@ public class SpoutRunner implements Runnable {
                     try {
                         tupleQueue.put(message);
                     } catch (InterruptedException ex) {
+
                         logger.error("Shutting down due to interruption {}", ex);
                         spout.requestStop();
                     }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunner.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunner.java
@@ -144,9 +144,8 @@ public class SpoutRunner implements Runnable {
                 if (message != null) {
                     try {
                         tupleQueue.put(message);
-                    } catch (InterruptedException ex) {
-
-                        logger.error("Shutting down due to interruption {}", ex);
+                    } catch (final InterruptedException interruptedException) {
+                        logger.error("Shutting down due to interruption {}", interruptedException.getMessage(), interruptedException);
                         spout.requestStop();
                     }
                 }
@@ -156,13 +155,13 @@ public class SpoutRunner implements Runnable {
 
                 // Ack anything that needs to be acked
                 while (!ackedTupleQueue.get(spout.getVirtualSpoutId()).isEmpty()) {
-                    MessageId id = ackedTupleQueue.get(spout.getVirtualSpoutId()).poll();
+                    final MessageId id = ackedTupleQueue.get(spout.getVirtualSpoutId()).poll();
                     spout.ack(id);
                 }
 
                 // Fail anything that needs to be failed
                 while (!failedTupleQueue.get(spout.getVirtualSpoutId()).isEmpty()) {
-                    MessageId id = failedTupleQueue.get(spout.getVirtualSpoutId()).poll();
+                    final MessageId id = failedTupleQueue.get(spout.getVirtualSpoutId()).poll();
                     spout.fail(id);
                 }
 
@@ -185,14 +184,12 @@ public class SpoutRunner implements Runnable {
             getTupleQueue().removeVirtualSpoutId(spout.getVirtualSpoutId());
             getAckedTupleQueue().remove(spout.getVirtualSpoutId());
             getFailedTupleQueue().remove(spout.getVirtualSpoutId());
-        } catch (Exception ex) {
-            // TODO: Should we restart the SpoutRunner?  I'd guess that SpoutMonitor should handle re-starting
-            logger.error("SpoutRunner for {} threw an exception {}", spout.getVirtualSpoutId(), ex);
-            ex.printStackTrace();
+        } catch (final Exception ex) {
+            // We don't handle restarting this instance.  Instead its Spout Monitor which that ownership falls to.
+            // We'll log the error, and bubble up the exception.
+            logger.error("SpoutRunner for {} threw an exception {}", spout.getVirtualSpoutId(), ex.getMessage(), ex);
 
-            // We re-throw the exception
-            // SpoutMonitor should detect this failed.
-            // TODO: Do we even want to bother catching this here?
+            // We re-throw the exception, SpoutMonitor will handle this.
             throw ex;
         }
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -57,6 +57,7 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.storm.generated.StreamInfo;
 import com.google.common.base.Charsets;
 import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.IRichSpout;
 import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.utils.Utils;
 import org.apache.zookeeper.KeeperException;
@@ -71,7 +72,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -994,6 +997,137 @@ public class DynamicSpoutTest {
         };
     }
 
+    /**
+     * Tests that pending errors get reported via OutputCollector.
+     */
+    @Test
+    public void testReportErrors() {
+        // Define config
+        //final Map<String, Object> config = getDefaultConfig("ConsumerIdPrefix", "StreamId");
+        final Map<String, Object> config = new HashMap<>();
+        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
+
+        // Create mocks
+        final TopologyContext topologyContext = new MockTopologyContext();
+        final MockSpoutOutputCollector mockSpoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create spout
+        final DynamicSpout spout = new DynamicSpout(config);
+
+        // Call open
+        spout.open(config, topologyContext, mockSpoutOutputCollector);
+
+        // Hook into error queue, and queue some errors
+        final Throwable exception1 = new RuntimeException("My RuntimeException");
+        final Throwable exception2 = new Exception("My Exception");
+
+        // "Report" our exceptions
+        spout.getCoordinator().getReportedErrorsQueue().add(exception1);
+        spout.getCoordinator().getReportedErrorsQueue().add(exception2);
+
+        // Call next tuple repeatedly, validate they get reported.
+        await()
+            .atMost(30, TimeUnit.SECONDS)
+            .until(() -> {
+                // Call next tuple
+                spout.nextTuple();
+
+                return mockSpoutOutputCollector.getReportedErrors().size() >= 2;
+            });
+
+        // Validate
+        final List<Throwable> reportedErrors = mockSpoutOutputCollector.getReportedErrors();
+        assertEquals("Should have 2 reported errors", 2, reportedErrors.size());
+        assertTrue("Contains first exception", reportedErrors.contains(exception1));
+        assertTrue("Contains second exception", reportedErrors.contains(exception2));
+
+        // Call close
+        spout.close();
+    }
+
+    /**
+     * Verifies that you do not define an output stream via the SidelineSpoutConfig
+     * declareOutputFields() method with default to using 'default' stream.
+     */
+    @Test
+    public void testDeclareOutputFields_without_stream() {
+        // Create config with null stream id config option.
+        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
+
+        // Define our output fields as key and value.
+        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
+
+        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+
+        // Create spout, but don't call open
+        final SidelineSpout spout = new SidelineSpout(config);
+
+        // call declareOutputFields
+        spout.declareOutputFields(declarer);
+
+        // Validate results.
+        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+
+        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
+        assertEquals(
+            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
+            Lists.newArrayList("key", "value")
+        );
+
+        spout.close();
+    }
+
+    /**
+     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
+     * in the declareOutputFields() method.
+     */
+    @Test
+    public void testDeclareOutputFields_with_stream() {
+        final String streamId = "foobar";
+        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
+
+        // Define our output fields as key and value.
+        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
+
+        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+
+        // Create spout, but do not call open.
+        final SidelineSpout spout = new SidelineSpout(config);
+
+        // call declareOutputFields
+        spout.declareOutputFields(declarer);
+
+        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+
+        assertTrue(fieldsDeclaration.containsKey(streamId));
+        assertEquals(
+            fieldsDeclaration.get(streamId).get_output_fields(),
+            Lists.newArrayList("key", "value")
+        );
+
+        spout.close();
+    }
+
+    /**
+     * Noop, just doing coverage!  These methods don't actually
+     * do anything right now anyways.
+     */
+    @Test
+    public void testActivate() {
+        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+        spout.activate();
+    }
+
+    /**
+     * Noop, just doing coverage!  These methods don't actually
+     * do anything right now anyways.
+     */
+    @Test
+    public void testDeactivate() {
+        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+        spout.deactivate();
+    }
+
     // Helper methods
 
     /**
@@ -1111,89 +1245,6 @@ public class DynamicSpoutTest {
                 // If all entries are empty, return true
                 return true;
             }, equalTo(true));
-    }
-
-    /**
-     * Verifies that you do not define an output stream via the SidelineSpoutConfig
-     * declareOutputFields() method with default to using 'default' stream.
-     */
-    @Test
-    public void testDeclareOutputFields_without_stream() {
-        // Create config with null stream id config option.
-        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
-
-        // Define our output fields as key and value.
-        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
-
-        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-
-        // Create spout, but don't call open
-        final SidelineSpout spout = new SidelineSpout(config);
-
-        // call declareOutputFields
-        spout.declareOutputFields(declarer);
-
-        // Validate results.
-        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-
-        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
-        assertEquals(
-            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
-            Lists.newArrayList("key", "value")
-        );
-
-        spout.close();
-    }
-
-    /**
-     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
-     * in the declareOutputFields() method.
-     */
-    @Test
-    public void testDeclareOutputFields_with_stream() {
-        final String streamId = "foobar";
-        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
-
-        // Define our output fields as key and value.
-        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
-
-        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-
-        // Create spout, but do not call open.
-        final SidelineSpout spout = new SidelineSpout(config);
-
-        // call declareOutputFields
-        spout.declareOutputFields(declarer);
-
-        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-
-        assertTrue(fieldsDeclaration.containsKey(streamId));
-        assertEquals(
-            fieldsDeclaration.get(streamId).get_output_fields(),
-            Lists.newArrayList("key", "value")
-        );
-
-        spout.close();
-    }
-
-    /**
-     * Noop, just doing coverage!  These methods don't actually
-     * do anything right now anyways.
-     */
-    @Test
-    public void testActivate() {
-        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-        spout.activate();
-    }
-
-    /**
-     * Noop, just doing coverage!  These methods don't actually
-     * do anything right now anyways.
-     */
-    @Test
-    public void testDeactivate() {
-        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-        spout.deactivate();
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1006,6 +1006,7 @@ public class DynamicSpoutTest {
         //final Map<String, Object> config = getDefaultConfig("ConsumerIdPrefix", "StreamId");
         final Map<String, Object> config = new HashMap<>();
         config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
 
         // Create mocks
         final TopologyContext topologyContext = new MockTopologyContext();
@@ -1025,7 +1026,7 @@ public class DynamicSpoutTest {
         spout.getCoordinator().getReportedErrorsQueue().add(exception1);
         spout.getCoordinator().getReportedErrorsQueue().add(exception2);
 
-        // Call next tuple repeatedly, validate they get reported.
+        // Call next tuple a couple times, validate errors get reported.
         await()
             .atMost(30, TimeUnit.SECONDS)
             .until(() -> {

--- a/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorTest.java
@@ -77,6 +77,9 @@ public class SpoutMonitorTest {
     private static final Logger logger = LoggerFactory.getLogger(SpoutMonitorTest.class);
     private static final int maxWaitTime = 5;
 
+    /**
+     * This is the executor pool we run tests against.
+     */
     private ThreadPoolExecutor executorService;
 
     /**
@@ -233,13 +236,13 @@ public class SpoutMonitorTest {
         // wait for it to be picked up
         // This means our queue should go to 0
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(newSpoutQueue::isEmpty, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(newSpoutQueue::isEmpty, equalTo(true));
 
         // Wait for spout count to increase
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(spoutMonitor::getTotalSpouts, equalTo(1));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(spoutMonitor::getTotalSpouts, equalTo(1));
 
         // validate the executor is running it
         assertEquals("Should have 1 running task", 1, spoutMonitor.getExecutor().getActiveCount());
@@ -259,8 +262,8 @@ public class SpoutMonitorTest {
 
         // Wait for it to stop running.
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(future::isDone, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(future::isDone, equalTo(true));
 
         // Verify close called on the mock spout
         verify(mockSpout, times(1)).close();
@@ -304,13 +307,13 @@ public class SpoutMonitorTest {
         // wait for it to be picked up
         // This means our queue should go to 0
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(newSpoutQueue::isEmpty, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(newSpoutQueue::isEmpty, equalTo(true));
 
         // Wait for spout count to increase
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(spoutMonitor::getTotalSpouts, equalTo(1));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(spoutMonitor::getTotalSpouts, equalTo(1));
 
         // Verify open was called
         assertTrue("open() should have been called", mockSpout.wasOpenCalled);
@@ -323,8 +326,8 @@ public class SpoutMonitorTest {
 
         // Wait for spout count to decrease
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(spoutMonitor::getTotalSpouts, equalTo(0));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(spoutMonitor::getTotalSpouts, equalTo(0));
 
         // validate the executor should no longer have any running tasks?
         assertEquals("Should have no running tasks", 0, spoutMonitor.getExecutor().getActiveCount());
@@ -334,8 +337,8 @@ public class SpoutMonitorTest {
 
         // Wait for it to stop running.
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(future::isDone, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(future::isDone, equalTo(true));
 
         // Verify closed was called
         assertTrue("Close() should have been called", mockSpout.wasCloseCalled);
@@ -383,13 +386,13 @@ public class SpoutMonitorTest {
         // wait for it to be picked up
         // This means our queue should go to 0
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(newSpoutQueue::isEmpty, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(newSpoutQueue::isEmpty, equalTo(true));
 
         // Wait for spout count to increase to the number of spout instances we submitted.
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(spoutMonitor::getTotalSpouts, equalTo(mockSpouts.size()));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(spoutMonitor::getTotalSpouts, equalTo(mockSpouts.size()));
 
         // Now the executor should only run a certain number
         assertEquals("Only configured max running concurrently", maxConccurentInstances, spoutMonitor.getExecutor().getActiveCount());
@@ -417,8 +420,8 @@ public class SpoutMonitorTest {
 
         // Wait for it to stop running.
         await()
-                .atMost(maxWaitTime, TimeUnit.SECONDS)
-                .until(future::isDone, equalTo(true));
+            .atMost(maxWaitTime, TimeUnit.SECONDS)
+            .until(future::isDone, equalTo(true));
 
         // Verify close was called on running spouts
         for (int x = 0; x < mockSpouts.size(); x++) {
@@ -554,17 +557,11 @@ public class SpoutMonitorTest {
         // Create instance.
         SpoutMonitor spoutMonitor = getDefaultMonitorInstance();
 
-        // Define how long to wait for async operations
-        final long testWaitTime = (spoutMonitor.getMonitorThreadIntervalMs() * 10);
-
         // Our new spout queue
         final Queue<DelegateSpout> newSpoutQueue = spoutMonitor.getNewSpoutQueue();
 
         // call run in async thread.
         final CompletableFuture future = startSpoutMonitor(spoutMonitor);
-
-        // Wait for it to fire up
-        Thread.sleep(testWaitTime);
 
         // Sanity test - Now validate we have no spouts submitted
         assertEquals("Should have no spouts", 0, spoutMonitor.getTotalSpouts());
@@ -591,7 +588,8 @@ public class SpoutMonitorTest {
         assertTrue("open() should have been called", mockSpout.wasOpenCalled);
 
         // Tell the spout to throw an exception.
-        mockSpout.exceptionToThrow = new RuntimeException("This is my runtime exception");
+        final RuntimeException runtimeException = new RuntimeException("This is my runtime exception");
+        mockSpout.exceptionToThrow = runtimeException;
 
         // Wait for spout count to decrease
         await()
@@ -605,6 +603,10 @@ public class SpoutMonitorTest {
         await()
             .atMost(maxWaitTime, TimeUnit.SECONDS)
             .until(future::isDone, equalTo(true));
+
+        // Verify that the exception error was reported.
+        assertEquals("Should have reported one error", 1, spoutMonitor.getReportedErrorsQueue().size());
+        assertTrue("Should be our reported error", spoutMonitor.getReportedErrorsQueue().contains(runtimeException));
 
         // Verify closed was called on the spout instance?
         //assertTrue("Close() should have been called", mockSpout.wasCloseCalled);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutMonitorTest.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -109,6 +110,7 @@ public class SpoutMonitorTest {
         final MessageBuffer messageBuffer = new FifoBuffer();
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> ackQueue = Maps.newConcurrentMap();
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> failQueue = Maps.newConcurrentMap();
+        final Queue<Throwable> errorQueue = Queues.newConcurrentLinkedQueue();
         final CountDownLatch latch = new CountDownLatch(0);
         final Clock clock = Clock.systemUTC();
 
@@ -130,6 +132,7 @@ public class SpoutMonitorTest {
             messageBuffer,
             ackQueue,
             failQueue,
+            errorQueue,
             latch,
             clock,
             topologyConfig,
@@ -628,6 +631,7 @@ public class SpoutMonitorTest {
         final MessageBuffer messageBuffer = new FifoBuffer();
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> ackQueue = Maps.newConcurrentMap();
         final Map<VirtualSpoutIdentifier, Queue<MessageId>> failQueue = Maps.newConcurrentMap();
+        final Queue<Throwable> errorQueue = Queues.newConcurrentLinkedQueue();
         final CountDownLatch latch = new CountDownLatch(0);
         final Clock clock = Clock.systemUTC();
 
@@ -644,6 +648,7 @@ public class SpoutMonitorTest {
             messageBuffer,
             ackQueue,
             failQueue,
+            errorQueue,
             latch,
             clock,
             topologyConfig,

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/output/MockSpoutOutputCollector.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/output/MockSpoutOutputCollector.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import org.apache.storm.spout.ISpoutOutputCollector;
 import org.apache.storm.spout.SpoutOutputCollector;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -39,7 +40,12 @@ public class MockSpoutOutputCollector extends SpoutOutputCollector {
     /**
      * This contains all of the Tuples that were 'emitted' to our MockOutputCollector.
      */
-    private List<SpoutEmission> emissions = Lists.newArrayList();
+    private final List<SpoutEmission> emissions = new ArrayList<>();
+
+    /**
+     * This contains any errors that were reported.
+     */
+    private final List<Throwable> reportedErrors = new ArrayList<>();
 
 
     public MockSpoutOutputCollector() {
@@ -48,9 +54,9 @@ public class MockSpoutOutputCollector extends SpoutOutputCollector {
 
     /**
      * Not used, but here to comply to SpoutOutputCollector interface.
-     * @param delegate - not used.
+     * @param delegate not used.
      */
-    public MockSpoutOutputCollector(ISpoutOutputCollector delegate) {
+    public MockSpoutOutputCollector(final ISpoutOutputCollector delegate) {
         super(delegate);
     }
 
@@ -61,8 +67,8 @@ public class MockSpoutOutputCollector extends SpoutOutputCollector {
      * @param streamId - the stream the tuple should be emitted down.
      * @param tuple - the tuple to emit
      * @param messageId - the tuple's message Id.
-     * @return - The interface is supposed to return the list of task ids that this tuple was sent to,
-     *           but here since we have no task ids to send the tuples to, no idea what to return.
+     * @return The interface is supposed to return the list of task ids that this tuple was sent to,
+     *         but here since we have no task ids to send the tuples to, no idea what to return.
      */
     @Override
     public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
@@ -84,17 +90,24 @@ public class MockSpoutOutputCollector extends SpoutOutputCollector {
     }
 
     @Override
-    public void reportError(Throwable error) {
-        // Not implemented yet.
+    public void reportError(final Throwable error) {
+        reportedErrors.add(error);
     }
 
     // Helper Methods
 
     /**
-     * @return - Return a clone of our Emissions in an unmodifiable list.
+     * @return Return a clone of our Emissions in an unmodifiable list.
      */
     public List<SpoutEmission> getEmissions() {
         return ImmutableList.copyOf(emissions);
+    }
+
+    /**
+     * @return Return a clone of reported errors in an unmodifiable list.
+     */
+    public List<Throwable> getReportedErrors() {
+        return ImmutableList.copyOf(reportedErrors);
     }
 
     /**
@@ -102,5 +115,6 @@ public class MockSpoutOutputCollector extends SpoutOutputCollector {
      */
     public void reset() {
         emissions.clear();
+        reportedErrors.clear();
     }
 }


### PR DESCRIPTION
First pass on #23 

This adds the ability for errors within Spout Coordinator / Spout Monitor to be bubbled up to storm.  We may want to continue this pattern and push access up into Virtual Spouts and/or Consumers?