### PR TITLE
Revamp Log4j2 configuration into something sane

### DIFF
--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,16 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<!-- Test Logging Configuration -->
+<Configuration>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %c{1.} [%t]: %msg%n"/>
         </Console>
+        <File name="File" fileName="target/logs/test.log" immediateFlush="true" append="true">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %c{1.} [%t]: %msg%n"/>
+        </File>
     </Appenders>
     <Loggers>
-        <Logger name="com.salesforce.storm.spout.dynamic" level="INFO"/>
-        <Logger name="com.salesforce.storm.spout.dynamic.config.SpoutConfig" level="ERROR"/>
-        <Logger name="org.apache.kafka" level="WARN"/>
-        <Root level="ERROR">
+        <!-- Relevant classes we want to see INFO logs on the Console -->
+        <Logger name="com.salesforce.storm.spout.dynamic" level="INFO">
             <AppenderRef ref="Console"/>
+        </Logger>
+        <Logger name="com.salesforce.storm.spout.dynamic.config.SpoutConfig" level="WARN">
+            <AppenderRef ref="Console"/>
+        </Logger>
+
+        <!-- Squelch noise from kafka -->
+        <Logger name="kafka" level="WARN">
+            <AppenderRef ref="File"/>
+        </Logger>
+        <Logger name="kafka.server" level="WARN">
+            <AppenderRef ref="File"/>
+        </Logger>
+        <Logger name="org.apache.kafka" level="WARN">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <!-- Squelch noise from zookeeper -->
+        <Logger name="org.apache.zookeeper" level="WARN">
+            <AppenderRef ref="File"/>
+        </Logger>
+        <Logger name="org.I0Itec.zkclient" level="WARN">
+            <AppenderRef ref="File"/>
+        </Logger>
+
+
+        <!-- Define our loggers -->
+        <Root level="INFO">
+            <!-- Only Errors go to console, except for the specific classpaths defined above -->
+            <AppenderRef level="ERROR" ref="Console"/>
+
+            <!-- Info level go to the log file -->
+            <AppenderRef level="INFO" ref="File"/>
         </Root>
+
     </Loggers>
 </Configuration>


### PR DESCRIPTION
@stanlemon We talked about this a little bit before.

This change shouldn't alter what gets logged to the console currently.  But it adds a new log file under target/logs/test.log  This log file gets all INFO level logs, excluding a few things I thought were non-relevant.

In intellJ you can adjust your default JUnit configuration to tail this log automatically.

<img width="719" alt="image" src="https://user-images.githubusercontent.com/571653/31849508-55ca83ca-b67e-11e7-9d85-989cedcc3b1a.png">
