### PR TITLE
[ISSUE-33] - trim output field values after splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-15](https://github.com/salesforce/storm-dynamic-spout/pull/15) Update Storm dependencies to 1.1.1
 - [PR-24](https://github.com/salesforce/storm-dynamic-spout/pull/24) Add ability for errors to be reported up to the Storm web UI.
 - [PR-34](https://github.com/salesforce/storm-dynamic-spout/pull/34) Add removeVirtualSpout() method to DynamicSpout
+- [PR-35](https://github.com/salesforce/storm-dynamic-spout/pull/35/files) Output fields should now be declared as a List of String objects. In 0.10 we will drop the comma delimited strings, in the interim we are also now trimming whitespace off of the comma delimited version. 
 
 ### Bug Fixes
 ##### Kafka Consumer

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -241,6 +241,11 @@ public class DynamicSpout extends BaseRichSpout {
             // List of String values.
             fields = new Fields((List<String>) fieldsCfgValue);
         } else if (fieldsCfgValue instanceof String) {
+            // Log deprecation warning.
+            logger.warn(
+                "Supplying configuration {} as a comma separated string is deprecated.  Please migrate your " +
+                "configuration to provide this option as a List.", SpoutConfig.OUTPUT_FIELDS
+            );
             // Comma separated
             fields = new Fields(Tools.splitAndTrim((String) fieldsCfgValue));
         } else if (fieldsCfgValue instanceof Fields) {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -41,6 +41,7 @@ import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
@@ -237,7 +238,7 @@ public class DynamicSpout extends BaseRichSpout {
         final Fields fields;
         if (fieldsCfgValue instanceof String) {
             // Comma separated
-            fields = new Fields(((String) fieldsCfgValue).split(","));
+            fields = new Fields(Tools.splitAndTrim((String) fieldsCfgValue));
         } else if (fieldsCfgValue instanceof Fields) {
             fields = (Fields) fieldsCfgValue;
         } else {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -243,8 +243,8 @@ public class DynamicSpout extends BaseRichSpout {
         } else if (fieldsCfgValue instanceof String) {
             // Log deprecation warning.
             logger.warn(
-                "Supplying configuration {} as a comma separated string is deprecated.  Please migrate your " +
-                "configuration to provide this option as a List.", SpoutConfig.OUTPUT_FIELDS
+                "Supplying configuration {} as a comma separated string is deprecated.  Please migrate your "
+                + "configuration to provide this option as a List.", SpoutConfig.OUTPUT_FIELDS
             );
             // Comma separated
             fields = new Fields(Tools.splitAndTrim((String) fieldsCfgValue));

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -41,7 +41,9 @@ import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -228,14 +230,17 @@ public class DynamicSpout extends BaseRichSpout {
      * @param declarer The output field declarer
      */
     @Override
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    public void declareOutputFields(final OutputFieldsDeclarer declarer) {
         // Handles both explicitly defined and default stream definitions.
         final String streamId = getOutputStreamId();
 
         // Construct fields from config
         final Object fieldsCfgValue = getSpoutConfigItem(SpoutConfig.OUTPUT_FIELDS);
         final Fields fields;
-        if (fieldsCfgValue instanceof String) {
+        if (fieldsCfgValue instanceof List && !((List) fieldsCfgValue).isEmpty() && ((List) fieldsCfgValue).get(0) instanceof String) {
+            // List of String values.
+            fields = new Fields((List<String>) fieldsCfgValue);
+        } else if (fieldsCfgValue instanceof String) {
             // Comma separated
             fields = new Fields(Tools.splitAndTrim((String) fieldsCfgValue));
         } else if (fieldsCfgValue instanceof Fields) {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -41,7 +41,6 @@ import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
@@ -25,10 +25,13 @@
 
 package com.salesforce.storm.spout.dynamic;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import org.apache.commons.collections.map.UnmodifiableMap;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -112,5 +115,25 @@ public class Tools {
             }
         }
         return clonedConfig;
+    }
+
+    /**
+     * Takes an input stream and splits on , returning an array of the values.  Each value is trim()'d
+     * and empty values are removed.
+     *
+     * @param input Input string to split.
+     * @return Array of trimmed values.
+     */
+    public static String[] splitAndTrim(final String input) {
+        // Validate non-null input.
+        Preconditions.checkNotNull(input);
+
+        // Split on , call trim(), filter empty values.
+        return Splitter.on(',')
+            .splitToList(input)
+            .stream()
+            .map(String::trim)
+            .filter((s) -> !s.isEmpty())
+            .toArray(String[]::new);
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Maps;
 import org.apache.commons.collections.map.UnmodifiableMap;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
@@ -132,7 +132,7 @@ public class Tools {
             .splitToList(input)
             .stream()
             .map(String::trim)
-            .filter((s) -> !s.isEmpty())
+            .filter((inputString) -> !inputString.isEmpty())
             .toArray(String[]::new);
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
@@ -54,11 +54,15 @@ public class SpoutConfig {
     public static final String OUTPUT_STREAM_ID = "spout.output_stream_id";
 
     /**
-     * (String) Defines the fields for the output stream in a comma separated list.
+     * (List[String]) Defines the output fields that the spout will emit as a list of field names.
+     * Example: ["field1", "field2", ...]
+     *
+     * Also supported as a single string of comma separated values: "field1, field2, ..."
+     * Or as an explicitly defined Fields object.
      */
     @Documentation(
-        description = "Defines the output fields that the spout will emit in a comma separated list",
-        type = String.class
+        description = "Defines the output fields that the spout will emit as a list of field names.",
+        type = List.class
     )
     public static final String OUTPUT_FIELDS = "spout.output_fields";
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/kafka/KafkaConsumerConfig.java
@@ -106,7 +106,6 @@ public class KafkaConsumerConfig {
 
         // Convert list to string
         final String brokerHostsStr = brokerHosts.stream()
-            .map(String::toString)
             .collect(Collectors.joining(","));
 
         // Autocommit is disabled, we handle offset tracking.

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1051,12 +1051,13 @@ public class DynamicSpoutTest {
      * declareOutputFields() method with default to using 'default' stream.
      */
     @Test
-    public void testDeclareOutputFields_without_stream() {
+    @UseDataProvider("provideOutputFields")
+    public void testDeclareOutputFields_without_stream(final String inputFields, final String[] expectedFields) {
         // Create config with null stream id config option.
         final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
 
         // Define our output fields as key and value.
-        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
+        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
 
         final OutputFieldsGetter declarer = new OutputFieldsGetter();
 
@@ -1072,7 +1073,7 @@ public class DynamicSpoutTest {
         assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
         assertEquals(
             fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
-            Lists.newArrayList("key", "value")
+            Lists.newArrayList(expectedFields)
         );
 
         spout.close();
@@ -1083,12 +1084,13 @@ public class DynamicSpoutTest {
      * in the declareOutputFields() method.
      */
     @Test
-    public void testDeclareOutputFields_with_stream() {
+    @UseDataProvider("provideOutputFields")
+    public void testDeclareOutputFields_with_stream(final String inputFields, final String[] expectedFields) {
         final String streamId = "foobar";
         final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
 
         // Define our output fields as key and value.
-        config.put(SpoutConfig.OUTPUT_FIELDS, "key,value");
+        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
 
         final OutputFieldsGetter declarer = new OutputFieldsGetter();
 
@@ -1103,10 +1105,22 @@ public class DynamicSpoutTest {
         assertTrue(fieldsDeclaration.containsKey(streamId));
         assertEquals(
             fieldsDeclaration.get(streamId).get_output_fields(),
-            Lists.newArrayList("key", "value")
+            Lists.newArrayList(expectedFields)
         );
 
         spout.close();
+    }
+
+    /**
+     * Provides various inputs to be split.
+     */
+    @DataProvider
+    public static Object[][] provideOutputFields() throws InstantiationException, IllegalAccessException {
+        return new Object[][]{
+            {"key,value", new String[] {"key", "value"} },
+            {"key, value", new String[] {"key", "value"} },
+            {" key    , value  ,", new String[] {"key", "value"} },
+        };
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/ToolsTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/ToolsTest.java
@@ -25,9 +25,13 @@
 
 package com.salesforce.storm.spout.dynamic;
 
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +43,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Provides test coverage over Tools methods.
  */
+@RunWith(DataProviderRunner.class)
 public class ToolsTest {
 
     /**
@@ -123,5 +128,49 @@ public class ToolsTest {
         assertEquals("Has value for key3", "value3", sourceMap.get(prefix + "key3"));
         assertEquals("Has value for key4", "value4", sourceMap.get("key4"));
         assertEquals("Has value for key5", "value5", sourceMap.get("key5"));
+    }
+
+    /**
+     * Call split and trim with null input, get null pointer.
+     */
+    @Test
+    public void testSplitAndTrimWithNullInput() {
+        expectedException.expect(NullPointerException.class);
+        Tools.splitAndTrim(null);
+    }
+
+    /**
+     * Call split and trim with null input, get null pointer.
+     */
+    @Test
+    @UseDataProvider("provideSplittableStrings")
+    public void testSplitAndTrim(final String input, final String[] expectedOutputValues) {
+        final String[] output = Tools.splitAndTrim(input);
+
+        // validate
+        assertNotNull(output);
+
+        assertEquals("Should have expected number of results", expectedOutputValues.length, output.length);
+        for (int x = 0; x < expectedOutputValues.length; x++) {
+            assertEquals("Has expected value", expectedOutputValues[x], output[x]);
+        }
+    }
+
+    /**
+     * Provides various inputs to be split.
+     */
+    @DataProvider
+    public static Object[][] provideSplittableStrings() throws InstantiationException, IllegalAccessException {
+        return new Object[][]{
+            { "a,b,c,d", new String[] { "a", "b", "c", "d" } },
+            { "my input", new String[] { "my input",} },
+            { "my input, your input", new String[] { "my input", "your input"} },
+            { "my input       ,         your    input   ", new String[] { "my input", "your    input"} },
+
+            // A couple special cases
+            { "a,b,", new String[] { "a","b" } },
+            { "a,,b", new String[] { "a","b" } },
+            { ",a,b", new String[] { "a","b" } }
+        };
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/ToolsTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/ToolsTest.java
@@ -140,7 +140,7 @@ public class ToolsTest {
     }
 
     /**
-     * Call split and trim with null input, get null pointer.
+     * Call split and trim with various input strings, validate we get the expected array of values back.
      */
     @Test
     @UseDataProvider("provideSplittableStrings")

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
@@ -560,7 +560,7 @@ public class ZookeeperPersistenceAdapterTest {
      * Helper method.
      */
     private Map createDefaultConfig(String zkServers, String zkRootNode, String consumerIdPrefix) {
-        return createDefaultConfig(Lists.newArrayList(zkServers.split(",")), zkRootNode, consumerIdPrefix);
+        return createDefaultConfig(Lists.newArrayList(Tools.splitAndTrim(zkServers)), zkRootNode, consumerIdPrefix);
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
@@ -26,6 +26,7 @@
 package com.salesforce.storm.spout.dynamic.persistence.zookeeper;
 
 import com.google.common.base.Charsets;
+import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.utils.SharedZookeeperTestResource;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.ClassRule;
@@ -109,7 +110,7 @@ public class CuratorHelperTest {
     private CuratorFramework createCurator() {
         // Create list of Servers
         final String serverStr = sharedZookeeperTestResource.getZookeeperConnectString();
-        final List<String> serverList = Arrays.asList(serverStr.split(","));
+        final List<String> serverList = Arrays.asList(Tools.splitAndTrim(serverStr));
 
         // Create config map
         final Map<String, Object> config = new HashMap<>();

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -509,7 +509,7 @@ public class ZookeeperPersistenceAdapterTest {
      * Helper method.
      */
     private Map createDefaultConfig(String zkServers, String zkRootNode, String consumerIdPrefix) {
-        return createDefaultConfig(Lists.newArrayList(zkServers.split(",")), zkRootNode, consumerIdPrefix);
+        return createDefaultConfig(Lists.newArrayList(Tools.splitAndTrim(zkServers)), zkRootNode, consumerIdPrefix);
     }
 
     /**


### PR DESCRIPTION
fix for #33 

Values are now split on ',' using Gauva's split library, trimmed, and filtered for empty values.