### PR TITLE
Drop VirtualSpout.getMaxLag() and pass the MetricsRecorder to Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Moved `FilterChain` back to the `dynamic` package.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 
+#### Removed
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
+
 #### Improvements
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps.
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) MetricRecorder is now passed into Consumer interface via open() method.
 
-#### Removed
-- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
 
 ### Sideline Framework
+#### Breaking Changes
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SpoutTriggerProxy` with `SidelineController` interface.
+
 #### Removed
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Removed deprecated code.
     - Remove deprecated constructor from SidelineRequest
     - Removed deprecated constructors from SidelineRequestIdentifier
     
-#### Breaking Changes
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SpoutTriggerProxy` with `SidelineController` interface.
-
 #### Improvements
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) When deserializing an invalid FilterChainStep it would crash the spout instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps. 
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) MetricRecorder is now passed into Consumer interface via open() method.
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Added lag, currentOffset, endOffset metrics to Kafka Consumer.
 
+### Removed
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,40 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.10.0 (RELEASE DATE TBD)
-### Improvements
-- [PR-38](https://github.com/salesforce/storm-dynamic-spout/pull/38) Removed unused method Deserializer.getOutputFields()
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Removed deprecated code.
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SpoutTriggerProxy` with `SidelineController` interface.
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Moved `FilterChain` back to the `dynamic` package. 
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps. 
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
-- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) MetricRecorder is now passed into Consumer interface via open() method.
-- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Added lag, currentOffset, endOffset metrics to Kafka Consumer.
 
-### Removed
+### DynamicSpout Framework
+#### Breaking Changes
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Moved `FilterChain` back to the `dynamic` package.
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
+
+#### Improvements
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps.
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) MetricRecorder is now passed into Consumer interface via open() method.
+
+#### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
 
-### Bug Fixes
+### Sideline Framework
+#### Removed
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Removed deprecated code.
+    - Remove deprecated constructor from SidelineRequest
+    - Removed deprecated constructors from SidelineRequestIdentifier
+    
+#### Breaking Changes
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SpoutTriggerProxy` with `SidelineController` interface.
 
-#### Sideline Spout
-- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) When deserializing an invalid FilterChainStep it would crash the spout instance. 
+#### Improvements
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) When deserializing an invalid FilterChainStep it would crash the spout instance.
 
-#### Kafka Consumer
+### Kafka Consumer
+#### Removed
+- [PR-38](https://github.com/salesforce/storm-dynamic-spout/pull/38) Removed unused method Deserializer.getOutputFields()
+
+#### Improvements
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Added lag, currentOffset, endOffset metrics to Kafka Consumer.
 - [PR-43](https://github.com/salesforce/storm-dynamic-spout/pull/43) Fixed unbounded recursion when calling fillBuffer() in the KafkaConsumer.
+
 
 ## 0.9.0 (2017-10-26)
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -340,7 +340,9 @@ SpoutMonitor | poolSize | Gauge | The max number of VirtualSpout instances that 
 SpoutMonitor | running | Gauge | The number of running VirtualSpout instances.
 SpoutMonitor | queued | Gauge | The number of queued VirtualSpout instances.
 SpoutMonitor | completed | Gauge | The number of completed VirtualSpout instances.
-
+Consumer | topic.`topic`.partition.`partition`.currentOffset | Gauge | Offset consumer has processed.
+Consumer | topic.`topic`.partition.`partition`.endOffset | Gauge | Offset for TAIL position in the partition.
+Consumer | topic.`topic`.partition.`partition`.lag | Gauge | Difference between endOffset and currentOffset metrics.
 
 # Sidelining
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
@@ -103,14 +103,6 @@ public interface DelegateSpout {
     ConsumerState getEndingState();
 
     /**
-     * Used by SpoutPartitionProgressMonitor to find the max lag of any partitions in the consumer for the current
-     * virtual spout.
-     * TODO This should be revisited, this feels out of place in the interface.
-     * @return Max lag.
-     */
-    double getMaxLag();
-
-    /**
      * Get the number of filters applied to spout's filter chain. Used for metrics in the spout monitor.
      * TODO Should we drop this metric? This feels out of place in the interface.
      * @return Number of filters applied.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -214,7 +214,7 @@ public class VirtualSpout implements DelegateSpout {
         );
 
         // Open consumer
-        consumer.open(spoutConfig, getVirtualSpoutId(), consumerPeerContext, persistenceAdapter, startingState);
+        consumer.open(spoutConfig, getVirtualSpoutId(), consumerPeerContext, persistenceAdapter, metricsRecorder, startingState);
 
         // This is an approximation, after the consumer has been opened since we were not provided with a starting state
         if (startingState == null) {
@@ -564,11 +564,6 @@ public class VirtualSpout implements DelegateSpout {
 
     public ConsumerState getEndingState() {
         return endingState;
-    }
-
-    @Override
-    public double getMaxLag() {
-        return consumer.getMaxLag();
     }
 
     @Override

--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
@@ -27,6 +27,7 @@ package com.salesforce.storm.spout.dynamic.consumer;
 
 import com.salesforce.storm.spout.dynamic.ConsumerPartition;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
 import com.salesforce.storm.spout.dynamic.persistence.PersistenceAdapter;
 
 import java.util.Map;
@@ -41,17 +42,19 @@ public interface Consumer {
     /**
      * This method is called once, after your implementation has been constructed.
      * This method should handle all setup and configuration.
-     * @param spoutConfig Configuration of Spout.
+     * @param spoutConfig spout configuration.
      * @param virtualSpoutIdentifier VirtualSpout running this consumer.
      * @param consumerPeerContext defines how many instances in total are running of this consumer.
-     * @param persistenceAdapter The persistence adapter used to manage any state.
-     * @param startingState (Optional) If not null, This defines the state at which the consumer should resume from.
+     * @param persistenceAdapter persistence adapter used to manage state.
+     * @param metricsRecorder metrics recorder for reporting metrics from the consumer.
+     * @param startingState (optional) if not null, this defines the state at which the consumer should resume from.
      */
     void open(
         final Map<String, Object> spoutConfig,
         final VirtualSpoutIdentifier virtualSpoutIdentifier,
         final ConsumerPeerContext consumerPeerContext,
         final PersistenceAdapter persistenceAdapter,
+        final MetricsRecorder metricsRecorder,
         final ConsumerState startingState
     );
 
@@ -85,12 +88,6 @@ public interface Consumer {
      * @return The Consumer's current state.
      */
     ConsumerState flushConsumerState();
-
-    /**
-     * This is likely to change in signature in the future to return some standardized object instead of a double.
-     * @return The consumer's maximum lag.
-     */
-    double getMaxLag();
 
     // The following methods are likely to be removed in future refactorings.
     void removeConsumerState();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutPartitionProgressMonitor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutPartitionProgressMonitor.java
@@ -71,9 +71,6 @@ class SpoutPartitionProgressMonitor {
             return;
         }
 
-        // This value is not partition specific and represents the maximum possible lag from the consumer for ANY partition
-        final double maxLag = spout.getMaxLag();
-
         // We can only track progress for partitions the consumer is currently subscribed to, so let's loop
         // over those.  It's possible there were more partitions in startingState, but we can't deal with
         // those if we are not currently getting state reported for them.
@@ -145,10 +142,6 @@ class SpoutPartitionProgressMonitor {
                 metricsRecorder.assignValue(VirtualSpout.class, metricKey + ".percentComplete", percentComplete);
             }
 
-            if (maxLag > 0L) {
-                metricsRecorder.assignValue(VirtualSpout.class, metricKey + ".maxLag", maxLag);
-            }
-
             if (startingOffset != null) {
                 metricsRecorder.assignValue(VirtualSpout.class, metricKey + ".startingOffset", startingOffset);
             }
@@ -171,24 +164,12 @@ class SpoutPartitionProgressMonitor {
                 );
             } else {
                 // TODO: If we have no endingOffset and our totalProcessed = 0, should we even bother writing this log
-
-                // Only log lag when we actually have it, we occasionally get -1 numbers when there is no lag
-                if (maxLag > 0) {
-                    logger.info(
-                        "Progress for {} on partition {}: {} processed (max lag of {})",
-                        spout.getVirtualSpoutId(),
-                        consumerPartition,
-                        totalProcessed,
-                        maxLag
-                    );
-                } else {
-                    logger.info(
-                        "Progress for {} on partition {}: {} processed",
-                        spout.getVirtualSpoutId(),
-                        consumerPartition,
-                        totalProcessed
-                    );
-                }
+                logger.info(
+                    "Progress for {} on partition {}: {} processed",
+                    spout.getVirtualSpoutId(),
+                    consumerPartition,
+                    totalProcessed
+                );
             }
         }
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -30,6 +30,7 @@ import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.consumer.ConsumerPeerContext;
 import com.salesforce.storm.spout.dynamic.consumer.Record;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
 import com.salesforce.storm.spout.dynamic.handler.NoopVirtualSpoutHandler;
@@ -247,6 +248,8 @@ public class VirtualSpoutTest {
         final FactoryManager factoryManager = spy(new FactoryManager(topologyConfig));
         when(factoryManager.createNewConsumerInstance()).thenReturn(mockConsumer);
 
+        final MetricsRecorder metricsRecorder = new LogRecorder();
+
         // Create virtual spout identifier
         final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("MyConsumerId");
 
@@ -256,7 +259,7 @@ public class VirtualSpoutTest {
             topologyConfig,
             mockTopologyContext,
             factoryManager,
-            new LogRecorder(),
+            metricsRecorder,
             null,
             null
         );
@@ -269,8 +272,10 @@ public class VirtualSpoutTest {
             anyMap(),
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
-            any(ZookeeperPersistenceAdapter.class
-        ), null, eq(null));
+            any(ZookeeperPersistenceAdapter.class),
+            eq(metricsRecorder),
+            eq(null)
+        );
 
         // Set expected exception
         expectedExceptionCallingOpenTwiceThrowsException.expect(IllegalStateException.class);
@@ -301,6 +306,8 @@ public class VirtualSpoutTest {
         when(mockFactoryManager.createNewPersistenceAdapterInstance()).thenReturn(mockPersistenceAdapter);
         when(mockFactoryManager.createNewConsumerInstance()).thenReturn(mockConsumer);
 
+        final MetricsRecorder metricsRecorder = new LogRecorder();
+
         // Create virtual spout identifier
         final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("MyConsumerId");
 
@@ -310,7 +317,7 @@ public class VirtualSpoutTest {
             topologyConfig,
             mockTopologyContext,
             mockFactoryManager,
-            new LogRecorder(),
+            metricsRecorder,
             null,
             null
         );
@@ -330,7 +337,8 @@ public class VirtualSpoutTest {
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
             any(ZookeeperPersistenceAdapter.class),
-            null, eq(null)
+            eq(metricsRecorder),
+            eq(null)
         );
     }
 

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -270,7 +270,7 @@ public class VirtualSpoutTest {
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
             any(ZookeeperPersistenceAdapter.class
-        ), eq(null));
+        ), null, eq(null));
 
         // Set expected exception
         expectedExceptionCallingOpenTwiceThrowsException.expect(IllegalStateException.class);
@@ -330,7 +330,7 @@ public class VirtualSpoutTest {
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
             any(ZookeeperPersistenceAdapter.class),
-            eq(null)
+            null, eq(null)
         );
     }
 

--- a/src/test/java/com/salesforce/storm/spout/dynamic/consumer/MockConsumer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/consumer/MockConsumer.java
@@ -28,13 +28,13 @@ package com.salesforce.storm.spout.dynamic.consumer;
 import com.google.common.collect.Maps;
 import com.salesforce.storm.spout.dynamic.ConsumerPartition;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.persistence.PersistenceAdapter;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -57,6 +57,7 @@ public class MockConsumer implements Consumer {
         VirtualSpoutIdentifier virtualSpoutIdentifier,
         ConsumerPeerContext consumerPeerContext,
         PersistenceAdapter persistenceAdapter,
+        MetricsRecorder metricsRecorder,
         ConsumerState startingState
     ) {
         this.activeVirtualSpoutIdentifier = virtualSpoutIdentifier;

--- a/src/test/java/com/salesforce/storm/spout/dynamic/consumer/MockConsumer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/consumer/MockConsumer.java
@@ -97,11 +97,6 @@ public class MockConsumer implements Consumer {
     }
 
     @Override
-    public double getMaxLag() {
-        return 0;
-    }
-
-    @Override
     public void removeConsumerState() {
 
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -153,7 +153,7 @@ public class ConsumerTest {
 
         // Call constructor
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, new LogRecorder(), null);
 
         // Validate our instances got set
         assertNotNull("Config is not null", consumer.getConsumerConfig());
@@ -231,14 +231,14 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // Now call open again, we expect this to throw an exception
         expectedExceptionCallConnectMultipleTimes.expect(IllegalStateException.class);
         expectedExceptionCallConnectMultipleTimes.expectMessage("open more than once");
 
         // Call it
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(),mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(),mockPersistenceAdapter, new LogRecorder(), null);
     }
 
     /**
@@ -287,7 +287,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -368,7 +368,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -461,7 +461,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -533,7 +533,7 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -636,7 +636,7 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, new LogRecorder(), null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -1148,7 +1148,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Read from namespace, verify we get what we expect
         for (int x = 0; x < numberOfRecordsToProduce; x++) {
@@ -1202,7 +1202,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, virtualSpoutIdentifier, getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Read from namespace, verify we get what we expect, we should only get the last 5 records.
         final List<Record> consumedRecords = asyncConsumeMessages(consumer, 5);
@@ -1406,7 +1406,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, new LogRecorder(), null);
 
         // Ask the underlying consumer for our assigned partitions.
         final Set<ConsumerPartition> assignedPartitions = consumer.getAssignedPartitions();
@@ -1559,7 +1559,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, new LogRecorder(), null);
 
         // Ask the underlying consumer for our assigned partitions.
         final Set<ConsumerPartition> assignedPartitions = consumer.getAssignedPartitions();
@@ -1887,7 +1887,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Validate PartitionOffsetManager is correctly setup
         ConsumerState consumerState = consumer.getCurrentState();
@@ -2003,7 +2003,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Validate PartitionOffsetManager is correctly setup
         ConsumerState consumerState = consumer.getCurrentState();
@@ -2177,7 +2177,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Attempt to retrieve records
         final List<Record> records = asyncConsumeMessages(consumer, numberOfExpectedMessages);
@@ -2276,7 +2276,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // Attempt to retrieve records
         final List<Record> records = asyncConsumeMessages(consumer, numberOfExpectedMessages);
@@ -2367,7 +2367,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, new LogRecorder(), null);
 
         // We are at the end of the log, so this should yield NULL every time, there's nothing after our offset
         final Record record1 = consumer.nextRecord();
@@ -2541,7 +2541,14 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(getDefaultConfig(topicName), getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
+        consumer.open(
+            getDefaultConfig(topicName),
+            getDefaultVSpoutId(),
+            getDefaultConsumerCohortDefinition(),
+            persistenceAdapter,
+            new LogRecorder(),
+            null
+        );
 
         return consumer;
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -40,6 +40,7 @@ import com.salesforce.storm.spout.dynamic.consumer.Record;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Deserializer;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.NullDeserializer;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
+import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.persistence.PersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
@@ -67,9 +68,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -90,7 +88,6 @@ import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -156,7 +153,7 @@ public class ConsumerTest {
 
         // Call constructor
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
 
         // Validate our instances got set
         assertNotNull("Config is not null", consumer.getConsumerConfig());
@@ -234,14 +231,14 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter,null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // Now call open again, we expect this to throw an exception
         expectedExceptionCallConnectMultipleTimes.expect(IllegalStateException.class);
         expectedExceptionCallConnectMultipleTimes.expectMessage("open more than once");
 
         // Call it
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(),mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(),mockPersistenceAdapter, null, null);
     }
 
     /**
@@ -290,7 +287,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -371,7 +368,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -464,7 +461,7 @@ public class ConsumerTest {
 
         // Call constructor injecting our mocks
         final Consumer consumer = new Consumer(mockKafkaConsumer);
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -536,7 +533,7 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -639,7 +636,7 @@ public class ConsumerTest {
         final Consumer consumer = new Consumer(mockKafkaConsumer);
 
         // Now call open
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), mockPersistenceAdapter, null, null);
 
         // For every partition returned by mockKafkaConsumer.partitionsFor(), we should subscribe to them via the
         // mockKafkaConsumer.assign() call
@@ -1151,7 +1148,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Read from namespace, verify we get what we expect
         for (int x = 0; x < numberOfRecordsToProduce; x++) {
@@ -1205,7 +1202,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, virtualSpoutIdentifier, getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Read from namespace, verify we get what we expect, we should only get the last 5 records.
         final List<Record> consumedRecords = asyncConsumeMessages(consumer, 5);
@@ -1409,7 +1406,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
 
         // Ask the underlying consumer for our assigned partitions.
         final Set<ConsumerPartition> assignedPartitions = consumer.getAssignedPartitions();
@@ -1562,7 +1559,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null);
+        consumer.open(config, virtualSpoutIdentifier, consumerPeerContext, persistenceAdapter, null, null);
 
         // Ask the underlying consumer for our assigned partitions.
         final Set<ConsumerPartition> assignedPartitions = consumer.getAssignedPartitions();
@@ -1890,7 +1887,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Validate PartitionOffsetManager is correctly setup
         ConsumerState consumerState = consumer.getCurrentState();
@@ -2006,7 +2003,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Validate PartitionOffsetManager is correctly setup
         ConsumerState consumerState = consumer.getCurrentState();
@@ -2180,7 +2177,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Attempt to retrieve records
         final List<Record> records = asyncConsumeMessages(consumer, numberOfExpectedMessages);
@@ -2279,7 +2276,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // Attempt to retrieve records
         final List<Record> records = asyncConsumeMessages(consumer, numberOfExpectedMessages);
@@ -2370,7 +2367,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(config, getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         // We are at the end of the log, so this should yield NULL every time, there's nothing after our offset
         final Record record1 = consumer.nextRecord();
@@ -2434,7 +2431,14 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer(kafkaConsumer);
-        consumer.open(getDefaultConfig(topicName), getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(
+            getDefaultConfig(topicName),
+            getDefaultVSpoutId(),
+            getDefaultConsumerCohortDefinition(),
+            persistenceAdapter,
+            new LogRecorder(),
+            null
+        );
 
         final Record record = consumer.nextRecord();
 
@@ -2537,7 +2541,7 @@ public class ConsumerTest {
 
         // Create our consumer
         final Consumer consumer = new Consumer();
-        consumer.open(getDefaultConfig(topicName), getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null);
+        consumer.open(getDefaultConfig(topicName), getDefaultVSpoutId(), getDefaultConsumerCohortDefinition(), persistenceAdapter, null, null);
 
         return consumer;
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -127,11 +127,6 @@ public class MockDelegateSpout implements DelegateSpout {
     }
 
     @Override
-    public double getMaxLag() {
-        return 0;
-    }
-
-    @Override
     public int getNumberOfFiltersApplied() {
         return 0;
     }


### PR DESCRIPTION
The getMaxLag() method has always felt awkward and it's another one of those situations where we are leaking our concerns across layers. I've wanted to switch this maxLag to be the endOffset and in other Consumer implementations we have a need for the ability to report metrics.  So this PR introduces the MetricsRecorder into the Consumer interface and drops the getMaxLag() metric in favor of a consumer specific one for the starting offset.