### PR TITLE
SidelineSpoutHandler should periodically check its state and recover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
 - [PR-52](https://github.com/salesforce/storm-dynamic-spout/pull/52) Remove Kafka-Test-Server.  Replace with Kafka-JUnit external dependency.
 
+### Improvements
+- [PR-38](https://github.com/salesforce/storm-dynamic-spout/pull/38) Removed unused method `Deserializer.getOutputFields()`.
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Removed deprecated code.
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SpoutTriggerProxy` with `SidelineController` interface.
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Moved `FilterChain` back to the `dynamic` package. 
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing `FilterChainStep` objects. 
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
+- [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added `isSidelineStarted()` and `isSidelineStopped()` to the `SidelineController`
+- [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them. 
+
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ sideline.persistence.zookeeper.root | String |  | Defines the root path to persi
 sideline.persistence.zookeeper.servers | List |  | Holds a list of Zookeeper server Hostnames + Ports in the following format: ["zkhost1:2181", "zkhost2:2181", ...] | 
 sideline.persistence.zookeeper.session_timeout | Integer |  | Zookeeper session timeout. | 
 sideline.persistence_adapter.class | String | Required | Defines which PersistenceAdapter implementation to use. Should be a full classpath to a class that implements the PersistenceAdapter interface. | 
+sideline.refresh_interval_seconds | Integer |  | Interval (in seconds) to check running sidelines and refresh them if necessary. | 
 sideline.trigger_class | String |  | Defines one or more sideline trigger(s) (if any) to use. Should be a fully qualified class path that implements thee SidelineTrigger interface. | 
 
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -395,6 +395,14 @@ public class DynamicSpout extends BaseRichSpout {
     }
 
     /**
+     * Get the total number of virtual spouts in the coordinator.
+     * @return total number of virtual spouts in the coordinator.
+     */
+    public int getTotalVirtualSpouts() {
+        return getCoordinator().getTotalSpouts();
+    }
+
+    /**
      * @return The spout's output collector.
      */
     private SpoutOutputCollector getOutputCollector() {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -396,6 +396,9 @@ public class DynamicSpout extends BaseRichSpout {
 
     /**
      * Get the total number of virtual spouts in the coordinator.
+     *
+     * This method crosses the thread barrier to determine its value.
+     *
      * @return total number of virtual spouts in the coordinator.
      */
     public int getTotalVirtualSpouts() {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -271,6 +271,8 @@ public class VirtualSpout implements DelegateSpout {
 
         startingState = null;
         endingState = null;
+
+        isOpened = false;
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -271,8 +271,6 @@ public class VirtualSpout implements DelegateSpout {
 
         startingState = null;
         endingState = null;
-
-        isOpened = false;
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/dynamic/kafka/deserializer/Utf8StringDeserializer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/kafka/deserializer/Utf8StringDeserializer.java
@@ -36,8 +36,8 @@ public class Utf8StringDeserializer implements Deserializer {
     @Override
     public Values deserialize(String topic, int partition, long offset, byte[] key, byte[] value) {
         return new Values(
-                new String(key, Charsets.UTF_8),
-                new String(value, Charsets.UTF_8)
+            new String(key, Charsets.UTF_8),
+            new String(value, Charsets.UTF_8)
         );
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
@@ -51,6 +51,15 @@ public class SidelineConfig {
     public static final String TRIGGER_CLASS = "sideline.trigger_class";
 
     /**
+     * (Integer) Interval (in seconds) to check running sidelines and refresh them if necessary.
+     */
+    @Documentation(
+        description = "Interval (in seconds) to check running sidelines and refresh them if necessary.",
+        type = Integer.class
+    )
+    public static final String REFRESH_INTERVAL_SECONDS = "sideline.refresh_interval_seconds";
+
+    /**
      * (String) Defines which PersistenceAdapter implementation to use.
      * Should be a full classpath to a class that implements the PersistenceAdapter interface.
      * Default Value: "com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter"
@@ -172,6 +181,16 @@ public class SidelineConfig {
                 "Unspecified configuration value for {} using default value {}",
                 PERSISTENCE_ZK_RETRY_INTERVAL,
                 clonedConfig.get(PERSISTENCE_ZK_RETRY_INTERVAL)
+            );
+        }
+
+        if (!clonedConfig.containsKey(REFRESH_INTERVAL_SECONDS)) {
+            // Default to 10 minutes
+            clonedConfig.put(REFRESH_INTERVAL_SECONDS, 600);
+            logger.info(
+                "Unspecified configuration value for {} using default value {}",
+                REFRESH_INTERVAL_SECONDS,
+                clonedConfig.get(REFRESH_INTERVAL_SECONDS)
             );
         }
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
@@ -54,7 +54,7 @@ public class SidelineConfig {
      * (Integer) Interval (in seconds) to check running sidelines and refresh them if necessary.
      */
     @Documentation(
-        description = "Interval (in seconds) to check running sidelines and refresh them if necessary.",
+        description = "Interval (in seconds) to check running sidelines and refresh them if necessary. Defaults to 600.",
         type = Integer.class
     )
     public static final String REFRESH_INTERVAL_SECONDS = "sideline.refresh_interval_seconds";

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -88,6 +88,11 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
     private TopologyContext topologyContext;
 
     /**
+     * Timer for periodically checking the state of the VirtualSpouts being managed.
+     */
+    private final Timer timer = new Timer();
+
+    /**
      * Collection of sideline triggers to manage.
      */
     private final List<SidelineTrigger> sidelineTriggers = new ArrayList<>();
@@ -159,7 +164,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
         Preconditions.checkArgument(
             spoutConfig.containsKey(SidelineConfig.REFRESH_INTERVAL_SECONDS)
             && spoutConfig.get(SidelineConfig.REFRESH_INTERVAL_SECONDS) != null,
-            "Refresh interval is required."
+            "Configuration value for " + SidelineConfig.REFRESH_INTERVAL_SECONDS + " is required."
         );
 
         final long refreshIntervalSeconds = ((Number) spoutConfig.get(SidelineConfig.REFRESH_INTERVAL_SECONDS)).longValue();
@@ -170,7 +175,6 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
         loadSidelines();
 
         // Repeat our sidelines check periodically
-        final Timer timer = new Timer();
         timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {
@@ -287,6 +291,8 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      */
     @Override
     public void onSpoutClose(final DynamicSpout spout) {
+        timer.cancel();
+
         final ListIterator<SidelineTrigger> iter = sidelineTriggers.listIterator();
 
         while (iter.hasNext()) {

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -156,7 +156,14 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
 
         createSidelineTriggers();
 
-        final long refreshIntervalSeconds = ((Number) spoutConfig.get(SidelineConfig.REFRESH_INTERVAL_SECONDS)).longValue();
+        final long refreshIntervalSeconds;
+
+        // This should be set by SidelineConfig.setDefaults(), but just in case we want to avoid the NullPointer
+        if (spoutConfig.containsKey(SidelineConfig.REFRESH_INTERVAL_SECONDS)) {
+            refreshIntervalSeconds = ((Number) spoutConfig.get(SidelineConfig.REFRESH_INTERVAL_SECONDS)).longValue();
+        } else {
+            refreshIntervalSeconds = 600;
+        }
 
         final long refreshIntervalMillis = TimeUnit.SECONDS.toMillis(refreshIntervalSeconds);
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -163,8 +163,8 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
     /**
      * Loads existing sideline requests that have been previously persisted and checks to make sure that they are running.
      */
-    private void loadSidelines() {
-        final VirtualSpoutIdentifier fireHoseIdentifier = new DefaultVirtualSpoutIdentifier(getVirtualSpoutIdPrefix() + ":" + MAIN_ID);
+    void loadSidelines() {
+        final VirtualSpoutIdentifier fireHoseIdentifier = getFireHoseSpoutIdentifier();
 
         // If we haven't spun up a VirtualSpout yet, we create it here.
         if (fireHoseSpout == null) {
@@ -542,6 +542,14 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      */
     VirtualSpout getFireHoseSpout() {
         return fireHoseSpout;
+    }
+
+    /**
+     * Get the firehose virtual spout identifier.
+     * @return firehose virtual spout identifier.
+     */
+    VirtualSpoutIdentifier getFireHoseSpoutIdentifier() {
+        return new DefaultVirtualSpoutIdentifier(getVirtualSpoutIdPrefix() + ":" + MAIN_ID);
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -1415,7 +1415,7 @@ public class DynamicSpoutTest {
         // Generate a unique zkRootNode for each test
         final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
 
-        final Map<String, Object> config = SpoutConfig.setDefaults(Maps.newHashMap());
+        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
 
         // Kafka Consumer config items
         config.put(SpoutConfig.CONSUMER_CLASS, Consumer.class.getName());

--- a/src/test/java/com/salesforce/storm/spout/dynamic/buffer/RoundRobinBufferTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/buffer/RoundRobinBufferTest.java
@@ -233,12 +233,10 @@ public class RoundRobinBufferTest {
 
         // Create new Thread
         final CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
-            System.out.println("Creating new iterator");
             Iterator<String> keyIterator = Iterators.cycle(myMap.keySet());
             while (keyIterator.hasNext()) {
                 final String keyValue = keyIterator.next();
                 if (keyValue.equals("Key5")) {
-                    System.out.println("Found new key! " + keyValue);
                     return keyValue;
                 }
             }
@@ -277,7 +275,6 @@ public class RoundRobinBufferTest {
 
         // Create new Thread
         final CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
-            System.out.println("Creating new iterator");
             Iterator<String> keyIterator = Iterators.cycle(myMap.keySet());
             int lastFound = 0;
             while (keyIterator.hasNext()) {
@@ -289,7 +286,6 @@ public class RoundRobinBufferTest {
                 }
                 // If we haven't seen this key in awhile
                 if (lastFound >= 12) {
-                    System.out.println("Hey Key4 is missing!");
                     return true;
                 }
             }
@@ -330,7 +326,6 @@ public class RoundRobinBufferTest {
 
         // Create new Thread
         final CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
-            System.out.println("Creating new iterator");
             Iterator<String> keyIterator = Iterators.cycle(myMap.keySet());
             while (keyIterator.hasNext()) {
                 final String keyValue = keyIterator.next();

--- a/src/test/java/com/salesforce/storm/spout/dynamic/filter/SerializerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/filter/SerializerTest.java
@@ -55,8 +55,6 @@ public class SerializerTest {
             filterChainStep
         );
 
-        System.out.println(serializedFilterChainStep);
-
         assertEquals(
             "FilterChainStep looks right serialized",
             "rO0ABXNyADZjb20uc2FsZXNmb3JjZS5zdG9ybS5zcG91dC5keW5hbWljLmZpbHRlci5OdW1iZXJGaWx0ZXKP3jjXh+gwbgIAAUkABm51bWJlcnhwAAAAKg==",

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -500,6 +500,37 @@ public class SidelineSpoutHandlerTest {
             spout.hasVirtualSpout(startRequestVirtualSpoutIdentifier)
         );
 
+        // Call this again, basically we want to be able to call this without messing with state and nothing else should change,
+        // so we'll validate that number of vspouts stays the same and the filter chain stays the same too.
+        sidelineSpoutHandler.loadSidelines();
+
+        assertEquals(
+            "Spout should have two virtual spouts",
+            2,
+            spout.getTotalVirtualSpouts()
+        );
+
+        assertTrue(
+            "Spout should have the firehose VirtualSpout",
+            spout.hasVirtualSpout(sidelineSpoutHandler.getFireHoseSpoutIdentifier())
+        );
+
+        assertTrue(
+            "Spout should have a VirtualSpout for the stop request",
+            spout.hasVirtualSpout(stopRequestVirtualSpoutIdentifier)
+        );
+
+        assertFalse(
+            "Spout should not have a VirtualSpout for the start request",
+            spout.hasVirtualSpout(startRequestVirtualSpoutIdentifier)
+        );
+
+        assertEquals(
+            "Firehose only has 1 filter",
+            1,
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().size()
+        );
+
         // Now we're going to mess with the state of the spout and filter chain and see if things reload properly
         spout.removeVirtualSpout(stopRequestVirtualSpoutIdentifier);
         spout.removeVirtualSpout(sidelineSpoutHandler.getFireHoseSpoutIdentifier());

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -44,6 +44,7 @@ import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import com.salesforce.storm.spout.sideline.trigger.SidelineType;
 import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
+import org.apache.storm.task.TopologyContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -51,7 +52,11 @@ import org.junit.rules.ExpectedException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
@@ -62,16 +67,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class SidelineSpoutHandlerTest {
 
+    private String CONSUMER_ID_PREFIX = "VirtualSpoutPrefix";
+
     /**
      * Test the open method properly stores the spout's config.
      */
     @Test
     public void testOpen() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
+        final Map<String, Object> config = getConfig();
 
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
         sidelineSpoutHandler.open(config);
@@ -87,12 +90,7 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testOnSpoutOpenCreatesFirehose() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "VirtualSpoutPrefix");
+        final Map<String, Object> config = getConfig();
 
         final PersistenceAdapter persistenceAdapter = new InMemoryPersistenceAdapter();
         persistenceAdapter.open(config);
@@ -114,18 +112,7 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testOnSpoutOpenResumesSidelines() {
-        final String consumerId = "VirtualSpoutPrefix";
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SpoutConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, consumerId);
-        config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
+        final Map<String, Object> config = getConfig();
 
         final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
         final StaticMessageFilter startFilter = new StaticMessageFilter();
@@ -135,7 +122,7 @@ public class SidelineSpoutHandlerTest {
         final StaticMessageFilter stopFilter = new StaticMessageFilter();
         final SidelineRequest stopRequest = new SidelineRequest(stopRequestId, stopFilter);
         final VirtualSpoutIdentifier virtualSpoutIdentifier2 = new SidelineVirtualSpoutIdentifier(
-            consumerId,
+            CONSUMER_ID_PREFIX,
             stopRequestId
         );
 
@@ -195,18 +182,7 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testStartSidelining() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, "VirtualSpoutPrefix");
-        config.put(KafkaConsumerConfig.KAFKA_TOPIC, "KafkaTopic");
-        config.put(
-            SpoutConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
+        final Map<String, Object> config = getConfig();
 
         final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
         final StaticMessageFilter startFilter = new StaticMessageFilter();
@@ -270,19 +246,7 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testStopSidelining() {
-        final String consumerId = "VirtualSpoutPrefix";
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, consumerId);
-        config.put(KafkaConsumerConfig.KAFKA_TOPIC, "KafkaTopic");
-        config.put(
-            SpoutConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
+        final Map<String, Object> config = getConfig();
 
         final SidelineRequestIdentifier stopRequestId = new SidelineRequestIdentifier("StopRequest");
         final StaticMessageFilter stopFilter = new StaticMessageFilter();
@@ -362,13 +326,7 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testOnSpoutClose() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "VirtualSpoutPrefix");
-        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
+        final Map<String, Object> config = getConfig();
 
         final PersistenceAdapter persistenceAdapter = new InMemoryPersistenceAdapter();
         persistenceAdapter.open(config);
@@ -397,12 +355,8 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testMisconfiguredCreateSidelineTriggers() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        // This class better not exist!
+        final Map<String, Object> config = getConfig();
+        // Override our trigger class with one that does not actually exist.
         config.put(SidelineConfig.TRIGGER_CLASS, "FooBar" + System.currentTimeMillis());
 
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
@@ -418,16 +372,10 @@ public class SidelineSpoutHandlerTest {
      */
     @Test
     public void testGenerateVirtualSpoutId() {
-        final String expectedPrefix = "VirtualSpoutPrefix";
         final SidelineRequestIdentifier expectedSidelineRequestIdentifier = new SidelineRequestIdentifier("SidelineRequestIdentifier");
 
         // Create our config, specify the consumer id because it will be used as a prefix
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            InMemoryPersistenceAdapter.class.getName()
-        );
-        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, expectedPrefix);
+        final Map<String, Object> config = getConfig();
 
         // Create a persistence adapter, this is called in the handler onSpoutOpen() method, we're just trying to avoid a NullPointer here
         final PersistenceAdapter persistenceAdapter = new InMemoryPersistenceAdapter();
@@ -449,7 +397,173 @@ public class SidelineSpoutHandlerTest {
 
         final SidelineVirtualSpoutIdentifier sidelineVirtualSpoutIdentifier = (SidelineVirtualSpoutIdentifier) virtualSpoutIdentifier;
 
-        assertEquals(expectedPrefix, sidelineVirtualSpoutIdentifier.getConsumerId());
+        assertEquals(CONSUMER_ID_PREFIX, sidelineVirtualSpoutIdentifier.getConsumerId());
         assertEquals(expectedSidelineRequestIdentifier, sidelineVirtualSpoutIdentifier.getSidelineRequestIdentifier());
+    }
+
+    /**
+     * Test that periodically calling {@link SidelineSpoutHandler#loadSidelines()} will restore {@link VirtualSpout}'s and
+     * {@link com.salesforce.storm.spout.dynamic.filter.FilterChainStep}'s after calling
+     * {@link SidelineSpoutHandler#onSpoutOpen(DynamicSpout, Map, TopologyContext)}, and that when spouts and filters are removed
+     * they are properly restored back onto the spout.
+     */
+    @Test
+    public void testLoadSidelines() {
+        final Map<String, Object> config = getConfig();
+
+        final DynamicSpout spout = new DynamicSpout(config);
+        spout.open(null, null, null);
+
+        final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
+        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.onSpoutOpen(spout, new HashMap(), new MockTopologyContext());
+
+        assertTrue(
+            "There should not be any filters on the firehose",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().isEmpty()
+        );
+
+        // The firehose has to move from the queue to a SpoutRunner, and this happens in a separate thread so we wait a bit.
+        await()
+            .until(() -> spout.getTotalVirtualSpouts(), equalTo(1));
+
+        assertEquals("Only the firehose should be on the spout", 1, spout.getTotalVirtualSpouts());
+
+        final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
+        final StaticMessageFilter startFilter = new StaticMessageFilter();
+        final SidelineRequest startRequest = new SidelineRequest(startRequestId, startFilter);
+
+        final SidelineRequestIdentifier stopRequestId = new SidelineRequestIdentifier("StopRequest");
+        final StaticMessageFilter stopFilter = new StaticMessageFilter();
+        final SidelineRequest stopRequest = new SidelineRequest(stopRequestId, stopFilter);
+
+        final PersistenceAdapter persistenceAdapter = sidelineSpoutHandler.getPersistenceAdapter();
+        // Make a starting request that we expect to be loaded
+        persistenceAdapter.persistSidelineRequestState(
+            SidelineType.START,
+            startRequestId,
+            startRequest,
+            0,
+            1L,
+            2L
+        );
+        // Make a stopping request that we expect to be loaded
+        persistenceAdapter.persistSidelineRequestState(
+            SidelineType.STOP,
+            stopRequestId,
+            stopRequest,
+            1,
+            3L,
+            4L
+        );
+
+        final VirtualSpoutIdentifier startRequestVirtualSpoutIdentifier = new SidelineVirtualSpoutIdentifier(
+            CONSUMER_ID_PREFIX,
+            startRequestId
+        );
+
+        final VirtualSpoutIdentifier stopRequestVirtualSpoutIdentifier = new SidelineVirtualSpoutIdentifier(
+            CONSUMER_ID_PREFIX,
+            stopRequestId
+        );
+
+        // Reload the sidelines, this is normally done via a thread on an interval - we're going to validate it behaves correctly now
+        sidelineSpoutHandler.loadSidelines();
+
+        assertFalse(
+            "There should be a filter on the firehose for our start request",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().isEmpty()
+        );
+
+        assertTrue(
+            "Start request should be on the filter chain",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
+                startRequestId
+            )
+        );
+
+        assertFalse(
+            "Stop request should not be on the filter chain",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
+                stopRequestId
+            )
+        );
+
+        // A new sideline spout should be added for our stopped request
+        await()
+            .until(() -> spout.getTotalVirtualSpouts(), equalTo(2));
+
+        assertTrue(
+            "Spout should have a VirtualSpout for the stop request",
+            spout.hasVirtualSpout(stopRequestVirtualSpoutIdentifier)
+        );
+
+        assertFalse(
+            "Spout should not have a VirtualSpout for the start request",
+            spout.hasVirtualSpout(startRequestVirtualSpoutIdentifier)
+        );
+
+        // Now we're going to mess with the state of the spout and filter chain and see if things reload properly
+        spout.removeVirtualSpout(stopRequestVirtualSpoutIdentifier);
+        spout.removeVirtualSpout(sidelineSpoutHandler.getFireHoseSpoutIdentifier());
+        sidelineSpoutHandler.getFireHoseSpout().getFilterChain().removeStep(startRequestId);
+
+        assertFalse(
+            "Spout should not have a VirtualSpout for the stop request",
+            spout.hasVirtualSpout(stopRequestVirtualSpoutIdentifier)
+        );
+
+        assertFalse(
+            "Spout should not have a VirtualSpout for the firehose",
+            spout.hasVirtualSpout(sidelineSpoutHandler.getFireHoseSpoutIdentifier())
+        );
+
+        assertFalse(
+            "Start request should not be on the filter chain",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
+                startRequestId
+            )
+        );
+
+        // The missing spout and filter chain step should be restored after this
+        sidelineSpoutHandler.loadSidelines();
+
+        assertTrue(
+            "Spout should have a VirtualSpout for the stop request",
+            // Note that this will be in the starting queue, not in the runners at this point and that's OK for this test
+            spout.hasVirtualSpout(stopRequestVirtualSpoutIdentifier)
+        );
+
+        assertTrue(
+            "Spout should have a VirtualSpout for the firehose",
+            spout.hasVirtualSpout(sidelineSpoutHandler.getFireHoseSpoutIdentifier())
+        );
+
+        assertTrue(
+            "Start request should be on the filter chain",
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
+                startRequestId
+            )
+        );
+
+        spout.close();
+    }
+
+    private Map<String, Object> getConfig() {
+        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
+        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, CONSUMER_ID_PREFIX);
+        config.put(KafkaConsumerConfig.KAFKA_TOPIC, "KafkaTopic");
+        config.put(
+            SpoutConfig.PERSISTENCE_ADAPTER_CLASS,
+            com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.class.getName()
+        );
+        config.put(
+            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+            InMemoryPersistenceAdapter.class.getName()
+        );
+        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
+        config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
+
+        return config;
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -546,6 +546,11 @@ public class SidelineSpoutHandlerTest {
             )
         );
 
+        // Note that I would love to mess with the filter chain on an existing VirtualSpout that isn't the FireHose, but there's no real way
+        // to get to the other spouts right now. This may not even be relevant either, because we never manipulate the sideline's filter
+        // chains after they've been opened (whereas we do with the firehose). In fact, it's not even possible to do because of the
+        // aforementioned lack of accessibility to non-firehose spouts.
+
         spout.close();
     }
 

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -579,7 +579,7 @@ public class SidelineSpoutHandlerTest {
     }
 
     private Map<String, Object> getConfig() {
-        final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
+        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(new HashMap<>()));
         config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, CONSUMER_ID_PREFIX);
         config.put(KafkaConsumerConfig.KAFKA_TOPIC, "KafkaTopic");
         config.put(

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -470,9 +470,10 @@ public class SidelineSpoutHandlerTest {
         // Reload the sidelines, this is normally done via a thread on an interval - we're going to validate it behaves correctly now
         sidelineSpoutHandler.loadSidelines();
 
-        assertFalse(
+        assertEquals(
             "There should be a filter on the firehose for our start request",
-            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().isEmpty()
+            1,
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().size()
         );
 
         assertTrue(

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -67,7 +67,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class SidelineSpoutHandlerTest {
 
-    private String CONSUMER_ID_PREFIX = "VirtualSpoutPrefix";
+    private static String CONSUMER_ID_PREFIX = "VirtualSpoutPrefix";
 
     /**
      * Test the open method properly stores the spout's config.
@@ -477,16 +477,12 @@ public class SidelineSpoutHandlerTest {
 
         assertTrue(
             "Start request should be on the filter chain",
-            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
-                startRequestId
-            )
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(startRequestId)
         );
 
         assertFalse(
             "Stop request should not be on the filter chain",
-            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
-                stopRequestId
-            )
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(stopRequestId)
         );
 
         // A new sideline spout should be added for our stopped request
@@ -520,9 +516,7 @@ public class SidelineSpoutHandlerTest {
 
         assertFalse(
             "Start request should not be on the filter chain",
-            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
-                startRequestId
-            )
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(startRequestId)
         );
 
         // The missing spout and filter chain step should be restored after this
@@ -541,9 +535,7 @@ public class SidelineSpoutHandlerTest {
 
         assertTrue(
             "Start request should be on the filter chain",
-            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(
-                startRequestId
-            )
+            sidelineSpoutHandler.getFireHoseSpout().getFilterChain().hasStep(startRequestId)
         );
 
         // Note that I would love to mess with the filter chain on an existing VirtualSpout that isn't the FireHose, but there's no real way

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -30,7 +30,7 @@
             <AppenderRef ref="File"/>
         </Logger>
 
-        <!-- Relevant classes we want to see INFO logs on the Console -->
+        <!-- Relevant classes we want to see ERROR logs on the Console and capture INFO (and everything else) in our log file -->
         <Logger name="com.salesforce.storm.spout.dynamic">
             <AppenderRef ref="Console" level="ERROR"/>
             <AppenderRef ref="File" level="INFO"/>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -10,14 +10,6 @@
         </File>
     </Appenders>
     <Loggers>
-        <!-- Relevant classes we want to see INFO logs on the Console -->
-        <Logger name="com.salesforce.storm.spout.dynamic" level="INFO">
-            <AppenderRef ref="Console"/>
-        </Logger>
-        <Logger name="com.salesforce.storm.spout.dynamic.config.SpoutConfig" level="WARN">
-            <AppenderRef ref="Console"/>
-        </Logger>
-
         <!-- Squelch noise from kafka -->
         <Logger name="kafka" level="WARN">
             <AppenderRef ref="File"/>
@@ -38,6 +30,14 @@
             <AppenderRef ref="File"/>
         </Logger>
 
+        <!-- Relevant classes we want to see INFO logs on the Console -->
+        <Logger name="com.salesforce.storm.spout.dynamic">
+            <AppenderRef ref="Console" level="ERROR"/>
+            <AppenderRef ref="File" level="INFO"/>
+        </Logger>
+        <Logger name="com.salesforce.storm.spout.dynamic.config.SpoutConfig" level="WARN">
+            <AppenderRef ref="File"/>
+        </Logger>
 
         <!-- Define our loggers -->
         <Root level="INFO">
@@ -47,6 +47,5 @@
             <!-- Info level go to the log file -->
             <AppenderRef level="INFO" ref="File"/>
         </Root>
-
     </Loggers>
 </Configuration>


### PR DESCRIPTION
VirtualSpouts can die. They shouldn't, but they do. FilterChains can get out of whack. They shouldn't, but they do. The SidelineSpoutHandler needs to periodically check its state and reload things to get them in the correct state.  This should be as simple as calling `loadSidelines()` periodically, but we need to add test coverage that jacking with the state of the spouts running and the various filter chains resumes correctly with subsequent calls. Then when all is said and done we can call loadSildelines() on an interval and we should be good to go.