### PR TITLE
Slightly tweak how the metrics are calculated, condense into a single loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps. 
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) MetricRecorder is now passed into Consumer interface via open() method.
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Added lag, currentOffset, endOffset metrics to Kafka Consumer.
 
+### Removed
+- [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
 
 ### Bug Fixes
 


### PR DESCRIPTION
This PR slightly tweaks your metric collection loops in the following way:

- It condenses the two loops into a single loop, 
- Renames some of the variables to be more explicit
- Re-uses the result of getCurrentState() instead of calling it once per loop iteration
- Adds "currentOffset" metric
- Renames the metric keyspace "topic.[topic].partition.[partition].[metricName]" so its easier to browse related metrics in something like grafana/graphite.
- Updates changelog <-- May want to review and make any other changes here that I missed.