### PR TITLE
Add missing close implementation, better naming of threads

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -180,7 +180,7 @@ public class SpoutCoordinator implements Runnable {
         isOpen = true;
 
         // Create and name thread.
-        final Thread thread = new Thread(this, "[DynamicSpout:SpoutCoordinator] for " + threadContext.toString());
+        final Thread thread = new Thread(this, "[DynamicSpout:Coordinator] Monitor for " + threadContext.toString());
 
         // Mark as a User thread.
         thread.setDaemon(false);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -147,7 +147,7 @@ public class SpoutCoordinator implements Runnable {
 
         // Create new ThreadFactory
         final String threadName = "[" + DynamicSpout.class.getSimpleName() + ":" + getClass().getSimpleName() + "] "
-            + "VirtualSpout Pool %d on " + threadContext.toString() + " ";
+            + VirtualSpout.class.getSimpleName() + " Pool %d on " + threadContext.toString() + " ";
         final ThreadFactory threadFactory = new ThreadFactoryBuilder()
             .setNameFormat(threadName)
             .setDaemon(false)

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -146,7 +146,7 @@ public class SpoutCoordinator implements Runnable {
 
         // Create new ThreadFactory
         final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("[DynamicSpout] Pool %d on " + threadContext.toString() + " ")
+            .setNameFormat("[DynamicSpout:Coordinator] Pool %d on " + threadContext.toString() + " ")
             .setDaemon(false)
             .build();
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -27,6 +27,7 @@ package com.salesforce.storm.spout.dynamic.coordinator;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.salesforce.storm.spout.dynamic.DynamicSpout;
 import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutMessageBus;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
@@ -145,8 +146,10 @@ public class SpoutCoordinator implements Runnable {
         this.threadContext = threadContext;
 
         // Create new ThreadFactory
+        final String threadName = "[" + DynamicSpout.class.getSimpleName() + ":" + getClass().getSimpleName() + "] "
+            + "VirtualSpout Pool %d on " + threadContext.toString() + " ";
         final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("[DynamicSpout:Coordinator] VirtualSpout Pool %d on " + threadContext.toString() + " ")
+            .setNameFormat(threadName)
             .setDaemon(false)
             .build();
 
@@ -180,7 +183,9 @@ public class SpoutCoordinator implements Runnable {
         isOpen = true;
 
         // Create and name thread.
-        final Thread thread = new Thread(this, "[DynamicSpout:Coordinator] Monitor for " + threadContext.toString());
+        final String threadName = "[" + DynamicSpout.class.getSimpleName() + ":" + getClass().getSimpleName() + "] "
+            + "Monitor for " + threadContext.toString();
+        final Thread thread = new Thread(this, threadName);
 
         // Mark as a User thread.
         thread.setDaemon(false);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -146,7 +146,7 @@ public class SpoutCoordinator implements Runnable {
 
         // Create new ThreadFactory
         final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-            .setNameFormat("[DynamicSpout:Coordinator] Pool %d on " + threadContext.toString() + " ")
+            .setNameFormat("[DynamicSpout:Coordinator] VirtualSpout Pool %d on " + threadContext.toString() + " ")
             .setDaemon(false)
             .build();
 
@@ -180,7 +180,7 @@ public class SpoutCoordinator implements Runnable {
         isOpen = true;
 
         // Create and name thread.
-        final Thread thread = new Thread(this, "[DynamicSpout] SpoutCoordinator on " + threadContext.toString());
+        final Thread thread = new Thread(this, "[DynamicSpout:SpoutCoordinator] for " + threadContext.toString());
 
         // Mark as a User thread.
         thread.setDaemon(false);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapter.java
@@ -90,7 +90,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         this.curator = CuratorFactory.createNewCuratorInstance(
             // Take out spout persistence config and strip the key from it for our factory.
             Tools.stripKeyPrefix("spout.persistence.zookeeper.", spoutConfig),
-            "PersistenceAdapter"
+            getClass().getSimpleName()
         );
 
         this.curatorHelper = new CuratorHelper(curator);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapter.java
@@ -89,7 +89,8 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
 
         this.curator = CuratorFactory.createNewCuratorInstance(
             // Take out spout persistence config and strip the key from it for our factory.
-            Tools.stripKeyPrefix("spout.persistence.zookeeper.", spoutConfig)
+            Tools.stripKeyPrefix("spout.persistence.zookeeper.", spoutConfig),
+            "PersistenceAdapter"
         );
 
         this.curatorHelper = new CuratorHelper(curator);
@@ -104,6 +105,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
             return;
         }
         curator.close();
+        curatorHelper = null;
         curator = null;
     }
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
@@ -72,6 +72,7 @@ public class CuratorFactory {
      * Create new curator instance based upon the provided config.
      *
      * @param config configuration object.
+     * @param context context about who is creating the instance.
      * @return curator instance.
      */
     public static CuratorFramework createNewCuratorInstance(final Map<String, Object> config, final String context) {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
@@ -27,6 +27,7 @@ package com.salesforce.storm.spout.dynamic.persistence.zookeeper;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.salesforce.storm.spout.dynamic.DynamicSpout;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
@@ -89,7 +90,7 @@ public class CuratorFactory {
             // Create new ThreadFactory with named threads.
             // TODO allow pushing in better naming.
             final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat("[DynamicSpout:" + context + "] Curator Pool %d")
+                .setNameFormat("[" + DynamicSpout.class.getSimpleName() + ":" + context + "] Curator Pool %d")
                 .setDaemon(false)
                 .build();
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
@@ -69,8 +68,6 @@ public class CuratorFactory {
      */
     private static final String CONFIG_RETRY_INTERVAL = "retry_interval";
 
-    private static final AtomicInteger counter = new AtomicInteger(0);
-
     /**
      * Create new curator instance based upon the provided config.
      *
@@ -91,7 +88,7 @@ public class CuratorFactory {
             // Create new ThreadFactory with named threads.
             // TODO allow pushing in better naming.
             final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat("[DynamicSpout:" + context + ":" + counter.incrementAndGet() + "] Curator Pool %d")
+                .setNameFormat("[DynamicSpout:" + context + "] Curator Pool %d")
                 .setDaemon(false)
                 .build();
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorFactory.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
@@ -68,13 +69,15 @@ public class CuratorFactory {
      */
     private static final String CONFIG_RETRY_INTERVAL = "retry_interval";
 
+    private static final AtomicInteger counter = new AtomicInteger(0);
+
     /**
      * Create new curator instance based upon the provided config.
      *
      * @param config configuration object.
      * @return curator instance.
      */
-    public static CuratorFramework createNewCuratorInstance(final Map<String, Object> config) {
+    public static CuratorFramework createNewCuratorInstance(final Map<String, Object> config, final String context) {
         // List of zookeeper hosts in the format of ["host1:2182", "host2:2181",..].
         final List<String> zkServers = (List<String>) config.get(CONFIG_SERVERS);
 
@@ -88,7 +91,7 @@ public class CuratorFactory {
             // Create new ThreadFactory with named threads.
             // TODO allow pushing in better naming.
             final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat("[DynamicSpout:PersistenceAdapter] Curator Pool %d")
+                .setNameFormat("[DynamicSpout:" + context + ":" + counter.incrementAndGet() + "] Curator Pool %d")
                 .setDaemon(false)
                 .build();
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -188,7 +188,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
         loadSidelines();
 
         // Repeat our sidelines check periodically
-        final String threadName = "[DynamicSpout:SidelineSpoutHandler] Timer on "
+        final String threadName = "[" + DynamicSpout.class.getSimpleName() + ":" + getClass().getSimpleName() + "] Timer on "
             + topologyContext.getThisComponentId() + ":" + topologyContext.getThisTaskIndex();
 
         timer = new Timer(threadName);

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -142,6 +142,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
 
         if (persistenceAdapter != null) {
             persistenceAdapter.close();
+            persistenceAdapter = null;
         }
 
         isOpen = false;

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
@@ -99,4 +99,15 @@ public class SidelineVirtualSpoutHandler implements VirtualSpoutHandler {
     PersistenceAdapter getPersistenceAdapter() {
         return persistenceAdapter;
     }
+
+    /**
+     * Close the handler.
+     */
+    public void close() {
+        if (getPersistenceAdapter() != null) {
+            getPersistenceAdapter().close();
+        }
+        persistenceAdapter = null;
+    }
+
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
@@ -110,5 +110,4 @@ public class SidelineVirtualSpoutHandler implements VirtualSpoutHandler {
     PersistenceAdapter getPersistenceAdapter() {
         return persistenceAdapter;
     }
-
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
@@ -93,21 +93,22 @@ public class SidelineVirtualSpoutHandler implements VirtualSpoutHandler {
     }
 
     /**
-     * Get the persistence adapter, only use this for tests!
-     * @return persistence adapter.
-     */
-    PersistenceAdapter getPersistenceAdapter() {
-        return persistenceAdapter;
-    }
-
-    /**
      * Close the handler.
      */
+    @Override
     public void close() {
         if (getPersistenceAdapter() != null) {
             getPersistenceAdapter().close();
         }
         persistenceAdapter = null;
+    }
+
+    /**
+     * Get the persistence adapter, only use this for tests!
+     * @return persistence adapter.
+     */
+    PersistenceAdapter getPersistenceAdapter() {
+        return persistenceAdapter;
     }
 
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -101,7 +101,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         this.curator = CuratorFactory.createNewCuratorInstance(
             // Take out sideline persistence config and strip the key from it for our factory.
             Tools.stripKeyPrefix("sideline.persistence.zookeeper.", spoutConfig),
-            "SidelinePersistenceAdapter"
+            "Sideline" + getClass().getSimpleName()
         );
 
         this.curatorHelper = new CuratorHelper(curator);

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -33,6 +33,7 @@ import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorFactory;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorHelper;
+import com.salesforce.storm.spout.sideline.SidelineSpout;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.dynamic.filter.FilterChainStep;
 import com.salesforce.storm.spout.dynamic.filter.Serializer;
@@ -101,7 +102,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         this.curator = CuratorFactory.createNewCuratorInstance(
             // Take out sideline persistence config and strip the key from it for our factory.
             Tools.stripKeyPrefix("sideline.persistence.zookeeper.", spoutConfig),
-            "Sideline" + getClass().getSimpleName()
+            SidelineSpout.class.getSimpleName() + ":" + getClass().getSimpleName()
         );
 
         this.curatorHelper = new CuratorHelper(curator);

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -100,7 +100,8 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
 
         this.curator = CuratorFactory.createNewCuratorInstance(
             // Take out sideline persistence config and strip the key from it for our factory.
-            Tools.stripKeyPrefix("sideline.persistence.zookeeper.", spoutConfig)
+            Tools.stripKeyPrefix("sideline.persistence.zookeeper.", spoutConfig),
+            "SidelinePersistenceAdapter"
         );
 
         this.curatorHelper = new CuratorHelper(curator);
@@ -115,6 +116,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
             return;
         }
         curator.close();
+        curatorHelper = null;
         curator = null;
     }
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
@@ -52,7 +52,6 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -140,7 +139,8 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
         );
 
         curator = CuratorFactory.createNewCuratorInstance(
-            Tools.stripKeyPrefix(Config.PREFIX, config)
+            Tools.stripKeyPrefix(Config.PREFIX, config),
+            "ZookeeperWatchTrigger"
         );
 
         curatorHelper = new CuratorHelper(curator);
@@ -222,7 +222,6 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
         if (curator != null) {
             curator.close();
             curator = null;
-
             curatorHelper = null;
         }
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
@@ -140,7 +140,7 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
 
         curator = CuratorFactory.createNewCuratorInstance(
             Tools.stripKeyPrefix(Config.PREFIX, config),
-            "ZookeeperWatchTrigger"
+            getClass().getSimpleName()
         );
 
         curatorHelper = new CuratorHelper(curator);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -61,7 +61,6 @@ import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
 import org.apache.zookeeper.KeeperException;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -61,6 +61,7 @@ import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
 import org.apache.zookeeper.KeeperException;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -564,9 +565,6 @@ public class DynamicSpoutTest {
         // Some mock stuff to get going
         TopologyContext topologyContext = new MockTopologyContext();
         MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-
-        final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
 
         // Create our spout, add references to our static trigger, and call open().
         DynamicSpout spout = new SidelineSpout(config);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
@@ -71,6 +71,9 @@ public class ZookeeperPersistenceAdapterTest {
     @ClassRule
     public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
 
+    /**
+     * By default no expected exceptions.
+     */
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -79,7 +82,7 @@ public class ZookeeperPersistenceAdapterTest {
      * an IllegalStateException.
      */
     @Test
-    public void testOpenMissingConfigForZkRootNode() throws InterruptedException {
+    public void testOpenMissingConfigForZkRootNode() {
         final List<String> inputHosts = Lists.newArrayList("localhost:2181", "localhost2:2183");
 
         // Create our config

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/ZookeeperPersistenceAdapterTest.java
@@ -72,14 +72,14 @@ public class ZookeeperPersistenceAdapterTest {
     public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
 
     @Rule
-    public ExpectedException expectedExceptionOpenMissingConfigForZkRootNode = ExpectedException.none();
+    public ExpectedException expectedException = ExpectedException.none();
 
     /**
      * Tests that if you're missing the configuration item for ZkRootNode it will throw
      * an IllegalStateException.
      */
     @Test
-    public void testOpenMissingConfigForZkRootNode() {
+    public void testOpenMissingConfigForZkRootNode() throws InterruptedException {
         final List<String> inputHosts = Lists.newArrayList("localhost:2181", "localhost2:2183");
 
         // Create our config
@@ -88,7 +88,8 @@ public class ZookeeperPersistenceAdapterTest {
         // Create instance and open it.
         ZookeeperPersistenceAdapter persistenceAdapter = new ZookeeperPersistenceAdapter();
 
-        expectedExceptionOpenMissingConfigForZkRootNode.expect(IllegalArgumentException.class);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("root is required");
         persistenceAdapter.open(topologyConfig);
     }
 
@@ -98,17 +99,14 @@ public class ZookeeperPersistenceAdapterTest {
     @Test
     public void testOpen() {
         final int partitionId = 1;
-        final String expectedZkConnectionString = "localhost:2181,localhost2:2183";
-        final List<String> inputHosts = Lists.newArrayList("localhost:2181", "localhost2:2183");
         final String configuredConsumerPrefix = "consumerIdPrefix";
         final String configuredZkRoot = getRandomZkRootNode();
         final String expectedZkRoot = configuredZkRoot + "/" + configuredConsumerPrefix;
         final String expectedConsumerId = configuredConsumerPrefix + ":MyConsumerId";
         final String expectedZkConsumerStatePath = expectedZkRoot + "/consumers/" + expectedConsumerId + "/" + String.valueOf(partitionId);
-        final String expectedZkRequestStatePath = expectedZkRoot + "/requests/" + expectedConsumerId + "/" + String.valueOf(partitionId);
 
         // Create our config
-        final Map topologyConfig = createDefaultConfig(inputHosts, configuredZkRoot, configuredConsumerPrefix);
+        final Map topologyConfig = createDefaultConfig(getZkServer().getConnectString(), configuredZkRoot, configuredConsumerPrefix);
 
         // Create instance and open it.
         ZookeeperPersistenceAdapter persistenceAdapter = new ZookeeperPersistenceAdapter();

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
@@ -117,6 +117,6 @@ public class CuratorHelperTest {
         final Map<String, Object> config = new HashMap<>();
         config.put("servers", serverList);
 
-        return CuratorFactory.createNewCuratorInstance(config);
+        return CuratorFactory.createNewCuratorInstance(config, getClass().getSimpleName());
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
@@ -104,5 +104,8 @@ public class SidelineVirtualSpoutHandlerTest {
             .retrieveSidelineRequest(sidelineRequestIdentifier, 5);
 
         assertNull(partition5);
+
+        // Call close
+        sidelineVirtualSpoutHandler.close();
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -79,8 +79,11 @@ public class ZookeeperPersistenceAdapterTest {
     @ClassRule
     public static final SharedZookeeperTestResource sharedZookeeperTestResource = new SharedZookeeperTestResource();
 
+    /**
+     * By default no expected exceptions.
+     */
     @Rule
-    public ExpectedException expectedExceptionOpenMissingConfigForZkRootNode = ExpectedException.none();
+    public ExpectedException expectedException = ExpectedException.none();
 
     /**
      * Tests that if you're missing the configuration item for ZkRootNode it will throw
@@ -96,7 +99,8 @@ public class ZookeeperPersistenceAdapterTest {
         // Create instance and open it.
         ZookeeperPersistenceAdapter persistenceAdapter = new ZookeeperPersistenceAdapter();
 
-        expectedExceptionOpenMissingConfigForZkRootNode.expect(IllegalArgumentException.class);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("root is required");
         persistenceAdapter.open(topologyConfig);
     }
 
@@ -106,17 +110,14 @@ public class ZookeeperPersistenceAdapterTest {
     @Test
     public void testOpen() {
         final int partitionId = 1;
-        final String expectedZkConnectionString = "localhost:2181,localhost2:2183";
-        final List<String> inputHosts = Lists.newArrayList("localhost:2181", "localhost2:2183");
         final String configuredConsumerPrefix = "consumerIdPrefix";
         final String configuredZkRoot = getRandomZkRootNode();
         final String expectedZkRoot = configuredZkRoot + "/" + configuredConsumerPrefix;
         final String expectedConsumerId = configuredConsumerPrefix + ":MyConsumerId";
-        final String expectedZkConsumerStatePath = expectedZkRoot + "/consumers/" + expectedConsumerId + "/" + String.valueOf(partitionId);
         final String expectedZkRequestStatePath = expectedZkRoot + "/requests/" + expectedConsumerId + "/" + String.valueOf(partitionId);
 
         // Create our config
-        final Map topologyConfig = createDefaultConfig(inputHosts, configuredZkRoot, configuredConsumerPrefix);
+        final Map topologyConfig = createDefaultConfig(getZkServer().getConnectString(), configuredZkRoot, configuredConsumerPrefix);
 
         // Create instance and open it.
         ZookeeperPersistenceAdapter persistenceAdapter = new ZookeeperPersistenceAdapter();

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
@@ -97,7 +97,8 @@ public class ZookeeperWatchTriggerTest {
         config.put(Config.FILTER_CHAIN_STEP_BUILDER_CLASS, MockFilterChainStepBuilder.class.getName());
 
         final CuratorFramework currator = CuratorFactory.createNewCuratorInstance(
-            Tools.stripKeyPrefix(Config.PREFIX, config)
+            Tools.stripKeyPrefix(Config.PREFIX, config),
+            getClass().getSimpleName()
         );
         final CuratorHelper curatorHelper = new CuratorHelper(currator);
 
@@ -214,7 +215,8 @@ public class ZookeeperWatchTriggerTest {
         config.put(Config.FILTER_CHAIN_STEP_BUILDER_CLASS, MockFilterChainStepBuilder.class.getName());
 
         final CuratorFramework currator = CuratorFactory.createNewCuratorInstance(
-            Tools.stripKeyPrefix(Config.PREFIX, config)
+            Tools.stripKeyPrefix(Config.PREFIX, config),
+            getClass().getSimpleName()
         );
         final CuratorHelper curatorHelper = new CuratorHelper(currator);
 


### PR DESCRIPTION
This PR deals with mysterious orphaned Curator threads within tests.

- Add close() definition to SidelineVirtualSpoutHandler implementation that closes Curator.
- Remove un-used SpoutHandler instance in test.
- Add context parameter to CuratorFactory.
