### PR TITLE
Breaking up Integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added isSidelineStarted() and isSidelineStopped() to the `SidelineController`
 - [PR-52](https://github.com/salesforce/storm-dynamic-spout/pull/52) Remove Kafka-Test-Server.  Replace with Kafka-JUnit external dependency.
+- [PR-66](https://github.com/salesforce/storm-dynamic-spout/pull/66) DynamicSpout.open() now throws IllegalStateException if you attempt to open it more than once.
 
 ### Improvements
 - [PR-38](https://github.com/salesforce/storm-dynamic-spout/pull/38) Removed unused method `Deserializer.getOutputFields()`.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -140,12 +140,12 @@ public class DynamicSpout extends BaseRichSpout {
      * @param topologyConfig The Storm Topology configuration.
      * @param topologyContext The Storm Topology context.
      * @param spoutOutputCollector The output collector to emit tuples via.
+     * @throws IllegalStateException if you attempt to open the spout multiple times.
      */
     @Override
     public void open(Map topologyConfig, TopologyContext topologyContext, SpoutOutputCollector spoutOutputCollector) {
         if (isOpen) {
-            logger.warn("This spout has already been opened, cowardly refusing to open it again!");
-            return;
+            throw new IllegalStateException("This spout has already been opened.");
         }
 
         // Save references.
@@ -405,6 +405,9 @@ public class DynamicSpout extends BaseRichSpout {
     /**
      * Add a new VirtualSpout to the coordinator, this will get picked up by the coordinator's monitor, opened and
      * managed with teh other currently running spouts.
+     *
+     * This method is blocking.
+     *
      * @param spout New delegate spout
      * @throws SpoutAlreadyExistsException if a spout already exists with the same VirtualSpoutIdentifier.
      */

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -317,9 +317,9 @@ public class DynamicSpout extends BaseRichSpout {
             metricsRecorder = null;
         }
 
-        if (spoutHandler != null) {
-            spoutHandler.onSpoutClose(this);
-            spoutHandler.close();
+        if (getSpoutHandler() != null) {
+            getSpoutHandler().onSpoutClose(this);
+            getSpoutHandler().close();
             spoutHandler = null;
         }
 
@@ -332,8 +332,8 @@ public class DynamicSpout extends BaseRichSpout {
     @Override
     public void activate() {
         logger.debug("Activating spout");
-        if (spoutHandler != null) {
-            spoutHandler.onSpoutActivate(this);
+        if (getSpoutHandler() != null) {
+            getSpoutHandler().onSpoutActivate(this);
         }
     }
 
@@ -343,8 +343,8 @@ public class DynamicSpout extends BaseRichSpout {
     @Override
     public void deactivate() {
         logger.debug("Deactivate spout");
-        if (spoutHandler != null) {
-            spoutHandler.onSpoutDeactivate(this);
+        if (getSpoutHandler() != null) {
+            getSpoutHandler().onSpoutDeactivate(this);
         }
     }
 
@@ -490,6 +490,14 @@ public class DynamicSpout extends BaseRichSpout {
     SpoutMessageBus getMessageBus() {
         checkSpoutOpened();
         return messageBus;
+    }
+
+    /**
+     * @return The SpoutHandler implementation.
+     */
+    SpoutHandler getSpoutHandler() {
+        checkSpoutOpened();
+        return spoutHandler;
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -32,8 +32,6 @@ import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.mocks.MockConsumer;
 import com.salesforce.storm.spout.dynamic.mocks.MockSpoutHandler;
 import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
-import com.salesforce.storm.spout.sideline.SidelineSpout;
-import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
 import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
 import com.salesforce.storm.spout.dynamic.mocks.MockTopologyContext;
@@ -674,14 +672,14 @@ public class DynamicSpoutTest {
     }
 
     /**
-     * Verifies that you do not define an output stream via the SidelineSpoutConfig
+     * Verifies that you do not define an output stream via the SpoutConfig
      * declareOutputFields() method with default to using 'default' stream.
      */
     @Test
     @UseDataProvider("provideOutputFields")
     public void testDeclareOutputFields_without_stream(final Object inputFields, final String[] expectedFields) {
         // Create config with null stream id config option.
-        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
+        final Map<String,Object> config = getDefaultConfig("DynamicSpout-", null);
 
         // Define our output fields as key and value.
         config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
@@ -689,7 +687,7 @@ public class DynamicSpoutTest {
         final OutputFieldsGetter declarer = new OutputFieldsGetter();
 
         // Create spout, but don't call open
-        final SidelineSpout spout = new SidelineSpout(config);
+        final DynamicSpout spout = new DynamicSpout(config);
 
         // call declareOutputFields
         spout.declareOutputFields(declarer);
@@ -707,14 +705,14 @@ public class DynamicSpoutTest {
     }
 
     /**
-     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
+     * Verifies that you can define an output stream via the SpoutConfig and it gets used
      * in the declareOutputFields() method.
      */
     @Test
     @UseDataProvider("provideOutputFields")
     public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
         final String streamId = "foobar";
-        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
+        final Map<String,Object> config = getDefaultConfig("DynamicSpout-", streamId);
 
         // Define our output fields as key and value.
         config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
@@ -722,7 +720,7 @@ public class DynamicSpoutTest {
         final OutputFieldsGetter declarer = new OutputFieldsGetter();
 
         // Create spout, but do not call open.
-        final SidelineSpout spout = new SidelineSpout(config);
+        final DynamicSpout spout = new DynamicSpout(config);
 
         // call declareOutputFields
         spout.declareOutputFields(declarer);
@@ -1114,7 +1112,7 @@ public class DynamicSpoutTest {
         final String consumerIdPrefix,
         final String configuredStreamId) {
 
-        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
+        final Map<String, Object> config = SpoutConfig.setDefaults(Maps.newHashMap());
 
         // Kafka Consumer config items
         config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -27,42 +27,28 @@ package com.salesforce.storm.spout.dynamic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.salesforce.kafka.test.KafkaTestServer;
-import com.salesforce.kafka.test.KafkaTestUtils;
-import com.salesforce.kafka.test.ProducedKafkaRecord;
-import com.salesforce.kafka.test.junit.SharedKafkaTestResource;
-import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
+import com.salesforce.storm.spout.dynamic.consumer.Record;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
+import com.salesforce.storm.spout.dynamic.mocks.MockConsumer;
+import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
 import com.salesforce.storm.spout.sideline.SidelineSpout;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
-import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
-import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
-import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
-import com.salesforce.storm.spout.dynamic.kafka.Consumer;
-import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
-import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
-import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
 import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
 import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
 import com.salesforce.storm.spout.dynamic.mocks.MockTopologyContext;
 import com.salesforce.storm.spout.dynamic.mocks.output.MockSpoutOutputCollector;
 import com.salesforce.storm.spout.dynamic.mocks.output.SpoutEmission;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
-import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
-import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
-import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.storm.generated.StreamInfo;
-import com.google.common.base.Charsets;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
-import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -72,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -87,24 +74,22 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * End to End integration testing of Sideline Spout under various scenarios.
+ * End to End integration testing of DynamicSpout under various scenarios.
  */
-// TODO: Remove sideline specific stuff from this test and create a separate test for those use cases.
 @RunWith(DataProviderRunner.class)
 public class DynamicSpoutTest {
     // For logging within the test.
     private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
 
     /**
-     * Create shared kafka test server.
-     */
-    @ClassRule
-    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
-
-    /**
      * We generate a unique topic name for every test case.
      */
     private String topicName;
+
+    /**
+     * We keep track of offsets we generate.
+     */
+    private long offset = 0;
 
     /**
      * This happens once before every test method.
@@ -115,16 +100,19 @@ public class DynamicSpoutTest {
         // Generate namespace name
         topicName = DynamicSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
 
-        // Create namespace
-        getKafkaTestServer().createTopic(topicName);
+        // Reset our MockConsumer
+        MockConsumer.reset();
     }
 
+    /**
+     * By default expect no exceptions.
+     */
     @Rule
-    public ExpectedException expectedExceptionMissingRequiredConfigurationConsumerIdPrefix = ExpectedException.none();
+    public ExpectedException expectedException = ExpectedException.none();
 
     /**
-     * Validates that we require the ConsumerIdPrefix configuration value,
-     * and if its missing we toss an IllegalStateException.
+     * Validates that we require the ConsumerIdPrefix configuration value.
+     * and if its missing we toss an IllegalStateException during open()
      */
     @Test
     public void testMissingRequiredConfigurationConsumerIdPrefix() {
@@ -137,11 +125,11 @@ public class DynamicSpoutTest {
         final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
 
         // Create spout and call open
-        final SidelineSpout spout = new SidelineSpout(config);
+        final DynamicSpout spout = new DynamicSpout(config);
 
         // When we call open, we expect illegal state exception about our missing configuration item
-        expectedExceptionMissingRequiredConfigurationConsumerIdPrefix.expect(IllegalStateException.class);
-        expectedExceptionMissingRequiredConfigurationConsumerIdPrefix.expectMessage(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX);
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX);
 
         // Call open
         spout.open(config, topologyContext, spoutOutputCollector);
@@ -149,24 +137,21 @@ public class DynamicSpoutTest {
 
     /**
      * Our most simple end-2-end test.
-     * This test stands up our spout and ask it to consume from our kafka namespace.
-     * We publish some data into kafka, and validate that when we call nextTuple() on
-     * our spout that we get out our messages that were published into kafka.
-     *
-     * This does not make use of any side lining logic, just simple consuming from the
-     * 'fire hose' consumer.
+     * This test stands up our spout and we add a single VirtualSpout using a "Mock Consumer."
+     * We instruct the "Mock Consumer" to "produce" some Records, and validate that when we call nextTuple() on
+     * our spout that we get out those tuples.
      *
      * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
      * output stream name (default), as well as an explicitly configured stream name.
      */
     @Test
     @UseDataProvider("provideStreamIds")
-    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
+    public void doBasicNextTupleTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
         // Define how many tuples we should push into the namespace, and then consume back out.
         final int emitTupleCount = 10;
 
         // Define our ConsumerId prefix
-        final String consumerIdPrefix = "TestSidelineSpout";
+        final String consumerIdPrefix = "TestDynamicSpout";
 
         // Create our config
         final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
@@ -182,26 +167,49 @@ public class DynamicSpoutTest {
         final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
 
         // Create spout and call open
-        final DynamicSpout spout = new SidelineSpout(config);
+        final DynamicSpout spout = new DynamicSpout(config);
         spout.open(config, topologyContext, spoutOutputCollector);
 
         // validate our streamId
         assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
 
-        // Call next tuple, namespace is empty, so nothing should get emitted.
+        // Create new unique VSpoutId
+        final VirtualSpoutIdentifier virtualSpoutIdentifier =
+            new DefaultVirtualSpoutIdentifier("MyVSpoutId" + System.currentTimeMillis());
+
+        // Add a VirtualSpout.
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for VirtualSpout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Call next tuple, consumer is empty, so nothing should get emitted.
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
 
-        // Lets produce some data into the namespace
-        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+        // Lets produce some data into the mock consumer
+        final List<Record> producedRecords = produceRecords(emitTupleCount, topicName, virtualSpout.getVirtualSpoutId());
 
         // Now consume tuples generated from the messages we published into kafka.
         final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
 
         // Validate the tuples that got emitted are what we expect based on what we published into kafka
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
 
         // Call next tuple a few more times to make sure nothing unexpected shows up.
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
+
+        // Lets remove the VirtualSpout and wait for it to shut down.
+        spout.removeVirtualSpout(virtualSpoutIdentifier);
+        waitForVirtualSpouts(spout, 0);
 
         // Cleanup.
         spout.close();
@@ -211,15 +219,12 @@ public class DynamicSpoutTest {
      * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
      * retry manager.
      *
-     * This test stands up our spout and ask it to consume from our kafka namespace.
-     * We publish some data into kafka, and validate that when we call nextTuple() on
-     * our spout that we get out our messages that were published into kafka.
+     * This test stands up our DynamicSpout with a single VirtualSpout using a "Mock Consumer"
+     * We inject some data into mock consumer, and validate that when we call nextTuple() on
+     * our spout that we get out our messages.
      *
-     * We then fail some tuples and validate that they get replayed.
+     * We then fail some of those tuples and validate that they get replayed.
      * We ack some tuples and then validate that they do NOT get replayed.
-     *
-     * This does not make use of any side lining logic, just simple consuming from the
-     * 'fire hose' namespace.
      */
     @Test
     public void doBasicFailTest() throws InterruptedException {
@@ -227,7 +232,7 @@ public class DynamicSpoutTest {
         final int emitTupleCount = 10;
 
         // Define our ConsumerId prefix
-        final String consumerIdPrefix = "SidelineSpout";
+        final String consumerIdPrefix = "DynamicSpout";
 
         // Define our output stream id
         final String expectedStreamId = "default";
@@ -236,6 +241,7 @@ public class DynamicSpoutTest {
         final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
 
         // Configure to use our FailedTuplesFirstRetryManager retry manager.
+        // This implementation will always replay failed tuples first.
         config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
 
         // Some mock stuff to get going
@@ -243,23 +249,42 @@ public class DynamicSpoutTest {
         final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
 
         // Create spout and call open
-        final DynamicSpout spout = new SidelineSpout(config);
+        final DynamicSpout spout = new DynamicSpout(config);
         spout.open(config, topologyContext, spoutOutputCollector);
 
         // validate our streamId
         assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
 
-        // Call next tuple, namespace is empty, so should get nothing.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+        // Create new unique VSpoutId
+        final VirtualSpoutIdentifier virtualSpoutIdentifier =
+            new DefaultVirtualSpoutIdentifier("MyVSpoutId" + System.currentTimeMillis());
 
-        // Lets produce some data into the namespace
-        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+        // Add a VirtualSpout.
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for VirtualSpout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Call next tuple, consumer is empty, so nothing should get emitted.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
+
+        // Lets produce some data into the mock consumer
+        final List<Record> producedRecords = produceRecords(emitTupleCount, topicName, virtualSpout.getVirtualSpoutId());
 
         // Now loop and get our tuples
         List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
 
         // Now lets validate that what we got out of the spout is what we actually expected.
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
 
         // Call next tuple a few more times to make sure nothing unexpected shows up.
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
@@ -270,7 +295,7 @@ public class DynamicSpoutTest {
         // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
         // And our retry manager should replay them first chance it gets.
         spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
 
         // Now lets ack 2 different offsets, entries 0 and 3.
         // This means they should never get replayed.
@@ -299,7 +324,7 @@ public class DynamicSpoutTest {
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
 
         // Validate the replayed tuples were our failed ones
-        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, consumerIdPrefix + ":main");
+        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, virtualSpoutIdentifier);
 
         // Now lets ack these
         ackTuples(spout, replayedEmissions);
@@ -312,557 +337,175 @@ public class DynamicSpoutTest {
     }
 
     /**
-     * Our most basic End 2 End test that includes basic sidelining.
-     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
-     * Records 1 and 2 we get out of the spout.
-     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
-     * We stop sidelining, this should cause a virtual spout to be started within the spout.
-     * Calling nextTuple() should get back the records that were previously skipped.
-     * We produce additional records into the namespace.
-     * Call nextTuple() and we should get them out.
+     * This test stands up a DynamicSpout instance running a single VirtualSpout that uses a "Mock Consumer".
+     * We'll inject some data into the Mock Consumer and get it back out using nextTuple().
+     * We'll then ack those tuples and validate that the ack notifications make it back
+     * to the Mock Consumer.
      */
     @Test
-    public void doTestWithSidelining() throws InterruptedException {
-        // How many records to publish into kafka per go.
-        final int numberOfRecordsToPublish = 3;
-
-        // Define our ConsumerId prefix
-        final String consumerIdPrefix = "TestSidelineSpout";
-
-        // Define our output stream id
-        final String expectedStreamId = "default";
-
-        // Create our Config
-        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-
-        // Create some stand-in mocks.
-        final TopologyContext topologyContext = new MockTopologyContext();
-        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create our spout, add references to our static trigger, and call open().
-        final DynamicSpout spout = new SidelineSpout(config);
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // validate our streamId
-        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-
-        // Produce records into kafka
-        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-
-        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
-        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
-        // to be emitted.
-        // Grab out the emissions so we can validate them.
-        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-
-        // Validate the tuples are what we published into kafka
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-
-        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
-        ackTuples(spout, spoutEmissions);
-
-        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
-        assertEquals("Should have a single VirtualSpout instance", 1, spout.getSpoutCoordinator().getTotalSpouts());
-
-        // Create a static message filter, this allows us to easily start filtering messages.
-        // It should filter ALL messages
-        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-
-        // Send a new start request with our filter.
-        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-        StaticTrigger.sendStartRequest(request);
-
-        // Produce another 3 records into kafka.
-        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-
-        // We basically want the time that would normally pass before we check that there are no new tuples
-        // Call next tuple, it should NOT receive any tuples because
-        // all tuples are filtered.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-
-        // Send a stop sideline request
-        StaticTrigger.sendStopRequest(request);
-
-        // We need to wait a bit for the sideline spout instance to spin up
-        waitForVirtualSpouts(spout, 2);
-
-        // Then ask the spout for tuples, we should get back the tuples that were produced while
-        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
-        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-
-        // We should validate these emissions
-        validateTuplesFromSourceMessages(
-            producedRecords,
-            spoutEmissions,
-            expectedStreamId,
-            consumerIdPrefix + ":sideline:" + request.id
-        );
-
-        // Call next tuple a few more times to be safe nothing else comes in.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-
-        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
-        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
-        assertEquals("We should have 2 virtual spouts running", 2, spout.getSpoutCoordinator().getTotalSpouts());
-
-        // Lets ack our messages.
-        ackTuples(spout, spoutEmissions);
-
-        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
-        // We need to wait for the monitor thread to run to clean it up.
-        waitForVirtualSpouts(spout, 1);
-
-        // Produce some more records, verify they come in the firehose.
-        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-
-        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-
-        // Loop over what we produced into kafka and validate them
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-
-        // Close out
-        spout.close();
-    }
-
-    /**
-     * This test stands up a spout instance and begins consuming from a namespace.
-     * Halfway thru consuming all the messages published in that namespace we will shutdown
-     * the spout gracefully.
-     *
-     * We'll create a new instance of the spout and fire it up, then validate that it resumes
-     * consuming from where it left off.
-     *
-     * Assumptions made in this test:
-     *   - single partition namespace
-     *   - using ZK persistence manager to maintain state between spout instances/restarts.
-     */
-    @Test
-    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException, KeeperException {
-        // Produce 10 messages into kafka (offsets 0->9)
-        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
-
+    public void testAckingTuples() throws InterruptedException, IOException {
         // Create spout
         // Define our output stream id
         final String expectedStreamId = "default";
-        final String consumerIdPrefix = "TestSidelineSpout";
+        final String consumerIdPrefix = "TestDynamicSpout";
 
         // Create our config
         final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-
-        // Use zookeeper persistence manager
-        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
 
         // Some mock stuff to get going
         TopologyContext topologyContext = new MockTopologyContext();
         MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
 
         // Create spout and call open
-        DynamicSpout spout = new SidelineSpout(config);
+        DynamicSpout spout = new DynamicSpout(config);
         spout.open(config, topologyContext, spoutOutputCollector);
 
-        // validate our streamId
-        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+        // Create new unique VSpoutId
+        final VirtualSpoutIdentifier virtualSpoutIdentifier =
+            new DefaultVirtualSpoutIdentifier("MyVSpoutId" + System.currentTimeMillis());
+
+        // Add a VirtualSpout.
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for VirtualSpout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Inject 10 messages into MockConsumer (offsets 0->9)
+        final List<Record> producedRecords = produceRecords(10, topicName, virtualSpoutIdentifier);
 
         // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
         final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
 
         // Validate its the messages we expected
-        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
+        validateEmission(producedRecords.get(0), spoutEmissions.get(0), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(1), spoutEmissions.get(1), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(2), spoutEmissions.get(2), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(3), spoutEmissions.get(3), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(4), spoutEmissions.get(4), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(5), spoutEmissions.get(5), virtualSpoutIdentifier, expectedStreamId);
 
-        // We will ack offsets in the following order: 2,0,1,3,5
-        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+        // We will ack offsets 0-4
         ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
         ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
         ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(4)));
+
+        // Wait for them to make it to the MockConsumer.
+        await()
+            .atMost(5, TimeUnit.SECONDS)
+            .until(() -> MockConsumer.getCommitted(virtualSpoutIdentifier).size(), equalTo(5));
+
+        // Validate that we've committed the appropriate offsets.
+        validateAckedTuples(virtualSpoutIdentifier, topicName, 0, 1, 2, 3, 4);
 
         // Stop the spout.
         // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-        spout.close();
-
-        // Create fresh new spoutOutputCollector & topology context
-        topologyContext = new MockTopologyContext();
-        spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create fresh new instance of spout & call open all with the same config
-        spout = new SidelineSpout(config);
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // Call next tuple to get remaining tuples out.
-        // It should give us offsets [4,5,6,7,8,9]
-        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
-            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
-        );
-
-        // Validate no further tuples
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-
-        // Validate its the tuples we expect [4,5,6,7,8,9]
-        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), consumerIdPrefix + ":main", expectedStreamId);
-
-        // Ack all tuples.
-        ackTuples(spout, spoutEmissionsAfterResume);
-
-        // Stop the spout.
-        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-        spout.close();
-
-        // Create fresh new spoutOutputCollector & topology context
-        topologyContext = new MockTopologyContext();
-        spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create fresh new instance of spout & call open all with the same config
-        spout = new SidelineSpout(config);
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // Validate no further tuples, as we acked all the things.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-
-        // And done.
         spout.close();
     }
 
     /**
-     * This test stands up a spout instance and tests sidelining.
-     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
-     * we stop the spout, create a new instance and restart it.  If things are working correctly
-     * the sidelined VirtualSpout should resume from where it left off.
+     * This is an integration test of multiple VirtualSpouts.
+     * - Start 2 VirtualSpouts
+     * - Inject records for both
+     * - Call nextTuple() and validate that we get them out.
+     * - Call ack() and validate that each VirtualSpout receives the ack()
+     * - Call fail() and validate that each VirtualSpout receives the fail()
      */
     @Test
-    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
-        // Produce 10 messages into kafka (offsets 0->9)
-        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+    public void testNextTupleAndAckUsingMultipleVirtualSpouts() {
+        final int numberOfMsgsPerVirtualSpout = 5;
+
+        // Create two topics
+        final String topic1 = "VSpout1Topic";
+        final String topic2 = "VSpout2Topic";
+
+        // Create two VirtualSpoutIdentifiers
+        final VirtualSpoutIdentifier vspoutId1 = new DefaultVirtualSpoutIdentifier("VSpout1");
+        final VirtualSpoutIdentifier vspoutId2 = new DefaultVirtualSpoutIdentifier("VSpout2");
+
+        // Inject 5 msgs for each VirtualSpout
+        produceRecords(numberOfMsgsPerVirtualSpout, topic1, vspoutId1);
+        produceRecords(numberOfMsgsPerVirtualSpout, topic2, vspoutId2);
 
         // Create spout
         // Define our output stream id
         final String expectedStreamId = "default";
-        final String consumerIdPrefix = "TestSidelineSpout";
+        final String consumerIdPrefix = "TestDynamicSpout";
 
         // Create our config
         final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-
-        // Use zookeeper persistence manager
-        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
-        );
-
-        // Some mock stuff to get going
-        TopologyContext topologyContext = new MockTopologyContext();
-        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create our spout, add references to our static trigger, and call open().
-        DynamicSpout spout = new SidelineSpout(config);
-
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // validate our streamId
-        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-
-        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
-        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
-
-        // Validate its the messages we expected
-        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
-
-        // We will ack offsets in the following order: 2,0,1,3,5
-        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
-
-        // Create a static message filter, this allows us to easily start filtering messages.
-        // It should filter ALL messages
-        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-
-        // Send a new start request with our filter.
-        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-        StaticTrigger.sendStartRequest(request);
-
-        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
-
-        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
-        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
-
-        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
-        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
-
-        // We'll validate them
-        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-
-        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
-
-        // Lets not ack any more tuples from the fire hose, that means the last completed
-        // offset on the fire hose spout should still be 3.
-
-        // Stop the spout.
-        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-        spout.close();
-
-        // A little debug log
-        logger.info("=== Starting spout again");
-        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
-
-        // Create new Spout instance and start
-        topologyContext = new MockTopologyContext();
-        spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create our spout, add references to our static trigger, and call open().
-        spout = new SidelineSpout(config);
-
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // Wait 3 seconds, then verify we have a single virtual spouts running
-        Thread.sleep(3000L);
-        waitForVirtualSpouts(spout, 1);
-
-        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
-        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
-
-        // Send a stop sideline request
-        StaticTrigger.sendStopRequest(request);
-
-        // Verify 2 VirtualSpouts are running
-        waitForVirtualSpouts(spout, 2);
-
-        // Call nextTuple() 3 times
-        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-
-        // Verify we get offsets [4,5,6] by validating the tuples
-        validateEmission(
-            producedRecords.get(4),
-            sidelinedEmissions.get(0),
-            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-            expectedStreamId
-        );
-        validateEmission(
-            producedRecords.get(5),
-            sidelinedEmissions.get(1),
-            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-            expectedStreamId
-        );
-        validateEmission(
-            producedRecords.get(6),
-            sidelinedEmissions.get(2),
-            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-            expectedStreamId
-        );
-
-        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
-        ackTuples(spout, sidelinedEmissions);
-
-        // Shut down spout.
-        spout.close();
-
-        // A little debug log
-        logger.info("=== Starting spout again");
-        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
-
-        // Create new spout instance and start
-        topologyContext = new MockTopologyContext();
-        spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create our spout, add references to our static trigger, and call open().
-        spout = new SidelineSpout(config);
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // Verify we have a 2 virtual spouts running
-        waitForVirtualSpouts(spout, 2);
-
-        // Since last committed offset should be 6,
-        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
-        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
-
-        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
-        // Gather up the expected records
-        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
-        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
-        sidelineKafkaRecords.addAll(additionalProducedRecords);
-
-        // Validate em.
-        validateTuplesFromSourceMessages(
-            sidelineKafkaRecords,
-            sidelinedEmissions,
-            expectedStreamId,
-            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier
-        );
-
-        // call nextTuple() several times, get nothing back
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-
-        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
-        ackTuples(spout, sidelinedEmissions);
-
-        // Verify 2nd VirtualSpout shuts off
-        waitForVirtualSpouts(spout, 1);
-        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
-
-        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
-        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
-
-        // Call nextTuple() 5 times,
-        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
-
-        // verify we get the tuples [15,16,17,18,19]
-        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-
-        // Ack offsets [15,16,18] => Committed offset should be 16
-        ackTuples(spout, Lists.newArrayList(
-            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
-        ));
-
-        // Verify no more tuples
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-
-        // Stop spout
-        spout.close();
-
-        // Create new spout instance and start.
-        topologyContext = new MockTopologyContext();
-        spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // A little debug log
-        logger.info("=== Starting spout for last time");
-        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
-
-
-        // Create our spout, add references to our static trigger, and call open().
-        spout = new SidelineSpout(config);
-
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // Verify we have a single 1 virtual spouts running,
-        // This makes sure that we don't resume a previously completed sideline request.
-        Thread.sleep(3000);
-        waitForVirtualSpouts(spout, 1);
-
-        // Call nextTuple() 3 times,
-        // verify we get offsets [17,18,19]
-        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-
-        // Validate we got the right offset [17,18,19]
-        validateTuplesFromSourceMessages(
-            lastProducedRecords.subList(2,5),
-            lastSpoutEmissions,
-            expectedStreamId,
-            consumerIdPrefix + ":main"
-        );
-
-        // Verify no more tuples
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-
-        // Stop spout.
-        spout.close();
-    }
-
-    /**
-     * This is an integration test of multiple SidelineConsumers.
-     * We stand up a namespace with 4 partitions.
-     * We then have a consumer size of 2.
-     * We run the test once using consumerIndex 0
-     *   - Verify we only consume from partitions 0 and 1
-     * We run the test once using consumerIndex 1
-     *   - Verify we only consume from partitions 2 and 3
-     * @param taskIndex What taskIndex to run the test with.
-     */
-    @Test
-    @UseDataProvider("providerOfTaskIds")
-    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
-        final int numberOfMsgsPerPartition = 10;
-
-        // Create a namespace with 4 partitions
-        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
-        getKafkaTestServer().createTopic(topicName, 4);
-
-        // Define some topicPartitions
-        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-
-        // produce 10 msgs into even partitions, 11 into odd partitions
-        produceRecords(numberOfMsgsPerPartition, 0);
-        produceRecords(numberOfMsgsPerPartition + 1, 1);
-        produceRecords(numberOfMsgsPerPartition, 2);
-        produceRecords(numberOfMsgsPerPartition + 1, 3);
-
-        // Some initial setup
-        final List<ConsumerPartition> expectedPartitions;
-        if (taskIndex == 0) {
-            // If we're consumerIndex 0, we expect partitionIds 0 or 1
-            expectedPartitions = Lists.newArrayList(partition0 , partition1);
-        } else if (taskIndex == 1) {
-            // If we're consumerIndex 0, we expect partitionIds 2 or 3
-            expectedPartitions = Lists.newArrayList(partition2 , partition3);
-        } else {
-            throw new RuntimeException("Invalid input to test");
-        }
-
-        // Create spout
-        // Define our output stream id
-        final String expectedStreamId = "default";
-        final String consumerIdPrefix = "TestSidelineSpout";
-
-        // Create our config
-        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-
-        // Use zookeeper persistence manager
-        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
 
         // Create topology context, set our task index
         MockTopologyContext topologyContext = new MockTopologyContext();
-        topologyContext.taskId = taskIndex;
-        topologyContext.taskIndex = taskIndex;
-
-        // Say that we have 2 tasks, ids 0 and 1
-        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-
         MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
 
-        // Create our spout, add references to our static trigger, and call open().
-        DynamicSpout spout = new SidelineSpout(config);
+        // Create our spout,
+        DynamicSpout spout = new DynamicSpout(config);
         spout.open(config, topologyContext, spoutOutputCollector);
 
         // validate our streamId
         assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
 
+        // Create two virtual Spouts
+        final VirtualSpout virtualSpout1 = new VirtualSpout(
+            vspoutId1,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        // Add a VirtualSpout.
+        final VirtualSpout virtualSpout2 = new VirtualSpout(
+            vspoutId2,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+
+        // Add them
+        spout.addVirtualSpout(virtualSpout1);
+        spout.addVirtualSpout(virtualSpout2);
+
         // Wait for our virtual spout to start
-        waitForVirtualSpouts(spout, 1);
+        waitForVirtualSpouts(spout, 2);
 
-        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
-        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
+        // Call next tuple 20 times, getting offsets 0-4 from the first vSpout, 5-9 on the 2nd vSpout
+        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerVirtualSpout * 2));
 
-        // Validate they all came from the correct partitions
+        // Validate they all came from the correct virtualSpouts
         for (SpoutEmission spoutEmission : spoutEmissions) {
             assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
 
             // Validate it came from the right place
             final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+
+            if (messageId.getSrcVirtualSpoutId() == vspoutId1) {
+                assertTrue("Should have offset >= 0 and <= 4", messageId.getOffset() >= 0 && messageId.getOffset() <= 4);
+                assertEquals("Should come from partition 0", 0, messageId.getPartition());
+                assertEquals("Should come from our namespace", topic1, messageId.getNamespace());
+            } else if (messageId.getSrcVirtualSpoutId() == vspoutId2) {
+                assertTrue("Should have offset >= 5 and <= 9", messageId.getOffset() >= 5 && messageId.getOffset() <= 9);
+                assertEquals("Should come from partition 0", 0, messageId.getPartition());
+                assertEquals("Should come from our namespace", topic2, messageId.getNamespace());
+            } else {
+                // Fail
+                assertFalse("Got unknown VirtualSpoutId! " + messageId.getSrcVirtualSpoutId(), true);
+            }
         }
 
         // Validate we don't have any other emissions
@@ -871,125 +514,20 @@ public class DynamicSpoutTest {
         // Lets ack our tuples
         ackTuples(spout, spoutEmissions);
 
-        // Close
-        spout.close();
-    }
+        // Wait for them to make it to the MockConsumer.
+        await()
+            .atMost(5, TimeUnit.SECONDS)
+            .until(() -> MockConsumer.getCommitted(vspoutId1).size(), equalTo(numberOfMsgsPerVirtualSpout));
+        await()
+            .atMost(5, TimeUnit.SECONDS)
+            .until(() -> MockConsumer.getCommitted(vspoutId2).size(), equalTo(numberOfMsgsPerVirtualSpout));
 
-    /**
-     * This is an integration test of multiple SidelineConsumers.
-     * We stand up a namespace with 4 partitions.
-     * We then have a consumer size of 2.
-     * We run the test once using consumerIndex 0
-     *   - Verify we only consume from partitions 0 and 1
-     * We run the test once using consumerIndex 1
-     *   - Verify we only consume from partitions 2 and 3
-     * @param taskIndex What taskIndex to run the test with.
-     */
-    @Test
-    @UseDataProvider("providerOfTaskIds")
-    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
-        final int numberOfMsgsPerPartition = 10;
-
-        // Create a namespace with 4 partitions
-        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
-        getKafkaTestServer().createTopic(topicName, 5);
-
-        // Define some topicPartitions
-        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
-
-        // produce 10 msgs into even partitions, 11 into odd partitions
-        produceRecords(numberOfMsgsPerPartition, 0);
-        produceRecords(numberOfMsgsPerPartition + 1, 1);
-        produceRecords(numberOfMsgsPerPartition, 2);
-        produceRecords(numberOfMsgsPerPartition + 1, 3);
-        produceRecords(numberOfMsgsPerPartition, 4);
-
-        // Some initial setup
-        final List<ConsumerPartition> expectedPartitions;
-        final int expectedNumberOfTuplesToConsume;
-        if (taskIndex == 0) {
-            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
-            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
-
-            // We expect to get out 31 tuples
-            expectedNumberOfTuplesToConsume = 31;
-        } else if (taskIndex == 1) {
-            // If we're consumerIndex 0, we expect partitionIds 3 or 4
-            expectedPartitions = Lists.newArrayList(partition3 , partition4);
-
-            // We expect to get out 21 tuples
-            expectedNumberOfTuplesToConsume = 21;
-        } else {
-            throw new RuntimeException("Invalid input to test");
-        }
-
-        // Create spout
-        // Define our output stream id
-        final String expectedStreamId = "default";
-        final String consumerIdPrefix = "TestSidelineSpout";
-
-        // Create our config
-        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-
-        // Use zookeeper persistence manager
-        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-
-        // Create topology context, set our task index
-        MockTopologyContext topologyContext = new MockTopologyContext();
-        topologyContext.taskId = taskIndex;
-        topologyContext.taskIndex = taskIndex;
-
-        // Say that we have 2 tasks, ids 0 and 1
-        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-
-        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-
-        // Create our spout, add references to our static trigger, and call open().
-        DynamicSpout spout = new SidelineSpout(config);
-        spout.open(config, topologyContext, spoutOutputCollector);
-
-        // validate our streamId
-        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-
-        // Wait for our virtual spout to start
-        waitForVirtualSpouts(spout, 1);
-
-        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
-        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
-
-        // Validate they all came from the correct partitions
-        for (SpoutEmission spoutEmission : spoutEmissions) {
-            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
-
-            // Validate it came from the right place
-            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
-        }
-
-        // Validate we don't have any other emissions
-        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
-
-        // Lets ack our tuples
-        ackTuples(spout, spoutEmissions);
+        // Now validate them
+        validateAckedTuples(vspoutId1, topic1, 0,1,2,3,4);
+        validateAckedTuples(vspoutId2, topic2, 5,6,7,8,9);
 
         // Close
         spout.close();
-    }
-
-    /**
-     * Provides task ids 0 and 1.
-     */
-    @DataProvider
-    public static Object[][] providerOfTaskIds() {
-        return new Object[][]{
-                {0},
-                {1}
-        };
     }
 
     /**
@@ -1155,20 +693,20 @@ public class DynamicSpoutTest {
      * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
      * got emitted by the spout, and make sure everything matches up to what we expected.
      *
-     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
+     * @param sourceRecord - The KafkaRecord messages published into kafka.
      * @param spoutEmission - The SpoutEmissions we got out of the spout
-     * @param expectedConsumerId - What consumerId these emissions should be associated with.
+     * @param expectedVirtualSpoutId - What VirtualSpoutId these emissions should be associated with.
      * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
      */
     private void validateEmission(
-        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
+        final Record sourceRecord,
         final SpoutEmission spoutEmission,
-        final String expectedConsumerId,
+        final VirtualSpoutIdentifier expectedVirtualSpoutId,
         final String expectedOutputStreamId
     ) {
         // Now find its corresponding tuple
         assertNotNull("Not null sanity check", spoutEmission);
-        assertNotNull("Not null sanity check", sourceProducerRecord);
+        assertNotNull("Not null sanity check", sourceRecord);
 
         // Validate Message Id
         assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
@@ -1176,12 +714,10 @@ public class DynamicSpoutTest {
 
         // Grab the messageId and validate it
         final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
-        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
-        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
-
-        // TODO: Should revisit this and refactor the test to properly pass around identifiers for validation
-        assertEquals("Expected Source Consumer Id", expectedConsumerId, messageId.getSrcVirtualSpoutId().toString());
+        assertEquals("Expected Topic Name in MessageId", sourceRecord.getNamespace(), messageId.getNamespace());
+        assertEquals("Expected PartitionId found", sourceRecord.getPartition(), messageId.getPartition());
+        assertEquals("Expected MessageOffset found", sourceRecord.getOffset(), messageId.getOffset());
+        assertEquals("Expected Source Consumer Id", expectedVirtualSpoutId, messageId.getSrcVirtualSpoutId());
 
         // Validate Tuple Contents
         List<Object> tupleValues = spoutEmission.getTuple();
@@ -1190,8 +726,8 @@ public class DynamicSpoutTest {
 
         // For now the values in the tuple should be 'key' and 'value', this may change.
         assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
-        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
-        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
+        assertEquals("Found expected 'key' value", sourceRecord.getValues().get(0), tupleValues.get(0));
+        assertEquals("Found expected 'value' value", sourceRecord.getValues().get(1), tupleValues.get(1));
 
         // Validate Emit Parameters
         assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
@@ -1225,6 +761,36 @@ public class DynamicSpoutTest {
                 // Wait for our tuples to get popped off the acked queue.
                 return messageBus.ackSize() == 0;
             }, equalTo(true));
+    }
+
+    /**
+     * Utility method to validate that the underlying MockConsumer got the right ack notification.
+     *
+     * @param virtualSpoutIdentifier What virtualSpout identifier to validate.
+     * @param expectedNamespace The expected namespace the acked tuples should be under.
+     * @param offsets Array of expected offsets.
+     */
+    private void validateAckedTuples(
+        final VirtualSpoutIdentifier virtualSpoutIdentifier,
+        final String expectedNamespace,
+        final long... offsets) {
+        // Validate that we've committed the appropriate offsets.
+        final List<MockConsumer.CommittedState> committed = MockConsumer.getCommitted(virtualSpoutIdentifier);
+        assertEquals("Should have right number of offsets", committed.size(), offsets.length);
+        for (final long expectedOffset : offsets) {
+            boolean found = false;
+            for (final MockConsumer.CommittedState committedState : committed) {
+                // Look for our specific committed offset.
+                if (committedState.getNamespace().equals(expectedNamespace)
+                    && committedState.getPartition() == 0
+                    && committedState.getOffset() == expectedOffset) {
+
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue("Found correct offset", found);
+        }
     }
 
     /**
@@ -1337,13 +903,13 @@ public class DynamicSpoutTest {
      *  @param producedRecords the original records produced into kafka.
      * @param spoutEmissions the tuples that got emitted out from the spout
      * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
-     * @param expectedConsumerId consumer id we expected
+     * @param expectedVirtualSpoutId virtual spout id we expected
      */
     private void validateTuplesFromSourceMessages(
-        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
+        final List<Record> producedRecords,
         final List<SpoutEmission> spoutEmissions,
         final String expectedStreamId,
-        final String expectedConsumerId
+        final VirtualSpoutIdentifier expectedVirtualSpoutId
     ) {
         // Sanity check, make sure we have the same number of each.
         assertEquals(
@@ -1357,12 +923,12 @@ public class DynamicSpoutTest {
         final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
 
         // Loop over what we produced into kafka
-        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
+        for (Record producedRecord: producedRecords) {
             // Now find its corresponding tuple from our iterator
             final SpoutEmission spoutEmission = emissionIterator.next();
 
             // validate that they match
-            validateEmission(producedRecord, spoutEmission, expectedConsumerId, expectedStreamId);
+            validateEmission(producedRecord, spoutEmission, expectedVirtualSpoutId, expectedStreamId);
         }
     }
 
@@ -1385,9 +951,23 @@ public class DynamicSpoutTest {
     /**
      * helper method to produce records into kafka.
      */
-    private List<ProducedKafkaRecord<byte[], byte[]>> produceRecords(int numberOfRecords, int partitionId) {
-        KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
-        return kafkaTestUtils.produceRecords(numberOfRecords, topicName, partitionId);
+    private List<Record> produceRecords(
+        final int numberOfRecords,
+        final String topic,
+        final VirtualSpoutIdentifier virtualSpoutIdentifier) {
+        // Generate random & unique data
+        final List<Record> records = new ArrayList<>();
+        for (int x = 0; x < numberOfRecords; x++) {
+            // Construct key and value
+            long myOffset = offset++;
+            String key = "key" + myOffset;
+            String value = "value" + myOffset;
+
+            // Add to map
+            records.add(new Record(topic, 0, myOffset, new Values(key, value)));
+        }
+        MockConsumer.injectRecords(virtualSpoutIdentifier, records);
+        return records;
     }
 
     /**
@@ -1396,35 +976,21 @@ public class DynamicSpoutTest {
      * @param consumerIdPrefix - consumerId prefix to use.
      * @param configuredStreamId - What streamId we should emit tuples out of.
      */
-    private Map<String, Object> getDefaultConfig(final String consumerIdPrefix, final String configuredStreamId) {
-        // Generate a unique zkRootNode for each test
-        final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
+    private Map<String, Object> getDefaultConfig(
+        final String consumerIdPrefix,
+        final String configuredStreamId) {
 
         final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
 
         // Kafka Consumer config items
-        config.put(SpoutConfig.CONSUMER_CLASS, Consumer.class.getName());
-        config.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
-        config.put(KafkaConsumerConfig.KAFKA_TOPIC, topicName);
-        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, consumerIdPrefix);
-        config.put(KafkaConsumerConfig.KAFKA_BROKERS, Lists.newArrayList(getKafkaTestServer().getKafkaConnectString()));
+        config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
+        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, consumerIdPrefix);
 
         // DynamicSpout config items
         config.put(SpoutConfig.RETRY_MANAGER_CLASS, NeverRetryManager.class.getName());
-        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
-        config.put(SpoutConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
 
-        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        // Use In Memory Persistence manager
         config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
-
-        // TODO: Separate the dependencies on this from this test!!!
-        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
-        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
-        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
 
         // Configure SpoutCoordinator thread to run every 1 second
         config.put(SpoutConfig.MONITOR_THREAD_INTERVAL_MS, 1000L);
@@ -1434,12 +1000,6 @@ public class DynamicSpoutTest {
 
         // For now use the Log Recorder
         config.put(SpoutConfig.METRICS_RECORDER_CLASS, LogRecorder.class.getName());
-
-        config.put(SpoutConfig.SPOUT_HANDLER_CLASS, SidelineSpoutHandler.class.getName());
-
-        config.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
-
-        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
 
         // If we have a stream Id we should be configured with
         if (configuredStreamId != null) {
@@ -1462,12 +1022,5 @@ public class DynamicSpoutTest {
                 // Explicitly defined streamId should get used as is.
                 { "SpecialStreamId", "SpecialStreamId" }
         };
-    }
-
-    /**
-     * Simple accessor.
-     */
-    private KafkaTestServer getKafkaTestServer() {
-        return sharedKafkaTestResource.getKafkaTestServer();
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
@@ -110,8 +110,7 @@ public class KafkaConsumerSpoutTest {
      * We publish some data into kafka, and validate that when we call nextTuple() on
      * our spout that we get out our messages that were published into kafka.
      *
-     * This does not make use of any side lining logic, just simple consuming from the
-     * 'fire hose' consumer.
+     * Uses a single VirtualSpout running the Kafka Consumer.
      *
      * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
      * output stream name (default), as well as an explicitly configured stream name.
@@ -188,8 +187,7 @@ public class KafkaConsumerSpoutTest {
      * We then fail some tuples and validate that they get replayed.
      * We ack some tuples and then validate that they do NOT get replayed.
      *
-     * This does not make use of any side lining logic, just simple consuming from the
-     * 'fire hose' namespace.
+     * Just simple consuming from a single VirtualSpout using the KafkaConsumer.
      */
     @Test
     public void doBasicFailTest() throws InterruptedException {

--- a/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
@@ -1,0 +1,1386 @@
+package com.salesforce.storm.spout.dynamic;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.salesforce.kafka.test.KafkaTestServer;
+import com.salesforce.kafka.test.KafkaTestUtils;
+import com.salesforce.kafka.test.ProducedKafkaRecord;
+import com.salesforce.kafka.test.junit.SharedKafkaTestResource;
+import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
+import com.salesforce.storm.spout.dynamic.kafka.Consumer;
+import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
+import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
+import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
+import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
+import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
+import com.salesforce.storm.spout.sideline.SidelineSpoutTest;
+import com.salesforce.storm.spout.sideline.config.SidelineConfig;
+import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
+import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
+import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import org.apache.storm.utils.Utils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class KafkaConsumerSpoutTest {
+    // For logging within the test.
+    private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
+
+    /**
+     * Create shared kafka test server.
+     */
+    @ClassRule
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
+
+    /**
+     * We generate a unique topic name for every test case.
+     */
+    private String topicName;
+
+    /**
+     * This happens once before every test method.
+     * Create a new empty namespace with randomly generated name.
+     */
+    @Before
+    public void beforeTest() throws InterruptedException {
+        // Generate namespace name
+        topicName = SidelineSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
+
+        // Create namespace
+        getKafkaTestServer().createTopic(topicName);
+    }
+
+//    /**
+//     * Our most simple end-2-end test.
+//     * This test stands up our spout and ask it to consume from our kafka namespace.
+//     * We publish some data into kafka, and validate that when we call nextTuple() on
+//     * our spout that we get out our messages that were published into kafka.
+//     *
+//     * This does not make use of any side lining logic, just simple consuming from the
+//     * 'fire hose' consumer.
+//     *
+//     * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
+//     * output stream name (default), as well as an explicitly configured stream name.
+//     */
+//    @Test
+//    @UseDataProvider("provideStreamIds")
+//    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
+//        // Define how many tuples we should push into the namespace, and then consume back out.
+//        final int emitTupleCount = 10;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
+//
+//        // If we have a stream Id we should be configured with
+//        if (configuredStreamId != null) {
+//            // Drop it into our configuration.
+//            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
+//        }
+//
+//        // Some mock storm topology stuff to get going
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple, namespace is empty, so nothing should get emitted.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
+//
+//        // Lets produce some data into the namespace
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+//
+//        // Now consume tuples generated from the messages we published into kafka.
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//
+//        // Validate the tuples that got emitted are what we expect based on what we published into kafka
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Call next tuple a few more times to make sure nothing unexpected shows up.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
+//
+//        // Cleanup.
+//        spout.close();
+//    }
+//
+//    /**
+//     * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
+//     * retry manager.
+//     *
+//     * This test stands up our spout and ask it to consume from our kafka namespace.
+//     * We publish some data into kafka, and validate that when we call nextTuple() on
+//     * our spout that we get out our messages that were published into kafka.
+//     *
+//     * We then fail some tuples and validate that they get replayed.
+//     * We ack some tuples and then validate that they do NOT get replayed.
+//     *
+//     * This does not make use of any side lining logic, just simple consuming from the
+//     * 'fire hose' namespace.
+//     */
+//    @Test
+//    public void doBasicFailTest() throws InterruptedException {
+//        // Define how many tuples we should push into the namespace, and then consume back out.
+//        final int emitTupleCount = 10;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "SidelineSpout";
+//
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Configure to use our FailedTuplesFirstRetryManager retry manager.
+//        config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
+//
+//        // Some mock stuff to get going
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple, namespace is empty, so should get nothing.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Lets produce some data into the namespace
+//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+//
+//        // Now loop and get our tuples
+//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//
+//        // Now lets validate that what we got out of the spout is what we actually expected.
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Call next tuple a few more times to make sure nothing unexpected shows up.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Now lets fail our tuples.
+//        failTuples(spout, spoutEmissions);
+//
+//        // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
+//        // And our retry manager should replay them first chance it gets.
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Now lets ack 2 different offsets, entries 0 and 3.
+//        // This means they should never get replayed.
+//        List<SpoutEmission> ackedEmissions = Lists.newArrayList();
+//        ackedEmissions.add(spoutEmissions.get(0));
+//        ackedEmissions.add(spoutEmissions.get(3));
+//        ackTuples(spout, ackedEmissions);
+//
+//        // And lets remove their related KafkaRecords
+//        // Remember to remove in reverse order, because ArrayLists have no gaps in indexes :p
+//        producedRecords.remove(3);
+//        producedRecords.remove(0);
+//
+//        // And lets fail the others
+//        List<SpoutEmission> failEmissions = Lists.newArrayList(spoutEmissions);
+//        failEmissions.removeAll(ackedEmissions);
+//        failTuples(spout, failEmissions);
+//
+//        // This is how many we failed.
+//        final int failedTuples = failEmissions.size();
+//
+//        // If we call nextTuple, we should get back our failed emissions
+//        final List<SpoutEmission> replayedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, failedTuples);
+//
+//        // Validate we don't get anything else
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate the replayed tuples were our failed ones
+//        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Now lets ack these
+//        ackTuples(spout, replayedEmissions);
+//
+//        // And validate nextTuple gives us nothing new
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Cleanup.
+//        spout.close();
+//    }
+//
+//    /**
+//     * Our most basic End 2 End test that includes basic sidelining.
+//     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
+//     * Records 1 and 2 we get out of the spout.
+//     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
+//     * We stop sidelining, this should cause a virtual spout to be started within the spout.
+//     * Calling nextTuple() should get back the records that were previously skipped.
+//     * We produce additional records into the namespace.
+//     * Call nextTuple() and we should get them out.
+//     */
+//    @Test
+//    public void doTestWithSidelining() throws InterruptedException {
+//        // How many records to publish into kafka per go.
+//        final int numberOfRecordsToPublish = 3;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//
+//        // Create our Config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Create some stand-in mocks.
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Produce records into kafka
+//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+//        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
+//        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
+//        // to be emitted.
+//        // Grab out the emissions so we can validate them.
+//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // Validate the tuples are what we published into kafka
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
+//        assertEquals("Should have a single VirtualSpout instance", 1, spout.getSpoutCoordinator().getTotalSpouts());
+//
+//        // Create a static message filter, this allows us to easily start filtering messages.
+//        // It should filter ALL messages
+//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+//
+//        // Send a new start request with our filter.
+//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+//        StaticTrigger.sendStartRequest(request);
+//
+//        // Produce another 3 records into kafka.
+//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // We basically want the time that would normally pass before we check that there are no new tuples
+//        // Call next tuple, it should NOT receive any tuples because
+//        // all tuples are filtered.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+//
+//        // Send a stop sideline request
+//        StaticTrigger.sendStopRequest(request);
+//
+//        // We need to wait a bit for the sideline spout instance to spin up
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Then ask the spout for tuples, we should get back the tuples that were produced while
+//        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // We should validate these emissions
+//        validateTuplesFromSourceMessages(
+//            producedRecords,
+//            spoutEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":sideline:" + request.id
+//        );
+//
+//        // Call next tuple a few more times to be safe nothing else comes in.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
+//        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
+//        assertEquals("We should have 2 virtual spouts running", 2, spout.getSpoutCoordinator().getTotalSpouts());
+//
+//        // Lets ack our messages.
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
+//        // We need to wait for the monitor thread to run to clean it up.
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Produce some more records, verify they come in the firehose.
+//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // Loop over what we produced into kafka and validate them
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Close out
+//        spout.close();
+//    }
+//
+//    /**
+//     * This test stands up a spout instance and begins consuming from a namespace.
+//     * Halfway thru consuming all the messages published in that namespace we will shutdown
+//     * the spout gracefully.
+//     *
+//     * We'll create a new instance of the spout and fire it up, then validate that it resumes
+//     * consuming from where it left off.
+//     *
+//     * Assumptions made in this test:
+//     *   - single partition namespace
+//     *   - using ZK persistence manager to maintain state between spout instances/restarts.
+//     */
+//    @Test
+//    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException, KeeperException {
+//        // Produce 10 messages into kafka (offsets 0->9)
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Some mock stuff to get going
+//        TopologyContext topologyContext = new MockTopologyContext();
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+//        final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
+//
+//        // Validate its the messages we expected
+//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // We will ack offsets in the following order: 2,0,1,3,5
+//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // Create fresh new spoutOutputCollector & topology context
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create fresh new instance of spout & call open all with the same config
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Call next tuple to get remaining tuples out.
+//        // It should give us offsets [4,5,6,7,8,9]
+//        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
+//            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
+//        );
+//
+//        // Validate no further tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate its the tuples we expect [4,5,6,7,8,9]
+//        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // Ack all tuples.
+//        ackTuples(spout, spoutEmissionsAfterResume);
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // Create fresh new spoutOutputCollector & topology context
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create fresh new instance of spout & call open all with the same config
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Validate no further tuples, as we acked all the things.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+//
+//        // And done.
+//        spout.close();
+//    }
+//
+//    /**
+//     * This test stands up a spout instance and tests sidelining.
+//     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
+//     * we stop the spout, create a new instance and restart it.  If things are working correctly
+//     * the sidelined VirtualSpout should resume from where it left off.
+//     */
+//    @Test
+//    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
+//        // Produce 10 messages into kafka (offsets 0->9)
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//        config.put(
+//            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+//            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
+//        );
+//
+//        // Some mock stuff to get going
+//        TopologyContext topologyContext = new MockTopologyContext();
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
+//
+//        // Validate its the messages we expected
+//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // We will ack offsets in the following order: 2,0,1,3,5
+//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+//
+//        // Create a static message filter, this allows us to easily start filtering messages.
+//        // It should filter ALL messages
+//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+//
+//        // Send a new start request with our filter.
+//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+//        StaticTrigger.sendStartRequest(request);
+//
+//        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
+//
+//        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
+//        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
+//
+//        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
+//        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
+//
+//        // We'll validate them
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
+//
+//        // Lets not ack any more tuples from the fire hose, that means the last completed
+//        // offset on the fire hose spout should still be 3.
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout again");
+//        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
+//
+//        // Create new Spout instance and start
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Wait 3 seconds, then verify we have a single virtual spouts running
+//        Thread.sleep(3000L);
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
+//        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
+//
+//        // Send a stop sideline request
+//        StaticTrigger.sendStopRequest(request);
+//
+//        // Verify 2 VirtualSpouts are running
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Call nextTuple() 3 times
+//        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+//
+//        // Verify we get offsets [4,5,6] by validating the tuples
+//        validateEmission(
+//            producedRecords.get(4),
+//            sidelinedEmissions.get(0),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//        validateEmission(
+//            producedRecords.get(5),
+//            sidelinedEmissions.get(1),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//        validateEmission(
+//            producedRecords.get(6),
+//            sidelinedEmissions.get(2),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//
+//        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
+//        ackTuples(spout, sidelinedEmissions);
+//
+//        // Shut down spout.
+//        spout.close();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout again");
+//        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
+//
+//        // Create new spout instance and start
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Verify we have a 2 virtual spouts running
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Since last committed offset should be 6,
+//        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
+//        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
+//
+//        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
+//        // Gather up the expected records
+//        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
+//        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
+//        sidelineKafkaRecords.addAll(additionalProducedRecords);
+//
+//        // Validate em.
+//        validateTuplesFromSourceMessages(
+//            sidelineKafkaRecords,
+//            sidelinedEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier
+//        );
+//
+//        // call nextTuple() several times, get nothing back
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
+//        ackTuples(spout, sidelinedEmissions);
+//
+//        // Verify 2nd VirtualSpout shuts off
+//        waitForVirtualSpouts(spout, 1);
+//        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
+//
+//        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
+//        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
+//
+//        // Call nextTuple() 5 times,
+//        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
+//
+//        // verify we get the tuples [15,16,17,18,19]
+//        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Ack offsets [15,16,18] => Committed offset should be 16
+//        ackTuples(spout, Lists.newArrayList(
+//            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
+//        ));
+//
+//        // Verify no more tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Stop spout
+//        spout.close();
+//
+//        // Create new spout instance and start.
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout for last time");
+//        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
+//
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Verify we have a single 1 virtual spouts running,
+//        // This makes sure that we don't resume a previously completed sideline request.
+//        Thread.sleep(3000);
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call nextTuple() 3 times,
+//        // verify we get offsets [17,18,19]
+//        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+//
+//        // Validate we got the right offset [17,18,19]
+//        validateTuplesFromSourceMessages(
+//            lastProducedRecords.subList(2,5),
+//            lastSpoutEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":main"
+//        );
+//
+//        // Verify no more tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Stop spout.
+//        spout.close();
+//    }
+//
+//    /**
+//     * This is an integration test of multiple SidelineConsumers.
+//     * We stand up a namespace with 4 partitions.
+//     * We then have a consumer size of 2.
+//     * We run the test once using consumerIndex 0
+//     *   - Verify we only consume from partitions 0 and 1
+//     * We run the test once using consumerIndex 1
+//     *   - Verify we only consume from partitions 2 and 3
+//     * @param taskIndex What taskIndex to run the test with.
+//     */
+//    @Test
+//    @UseDataProvider("providerOfTaskIds")
+//    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
+//        final int numberOfMsgsPerPartition = 10;
+//
+//        // Create a namespace with 4 partitions
+//        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
+//        getKafkaTestServer().createTopic(topicName, 4);
+//
+//        // Define some topicPartitions
+//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+//
+//        // produce 10 msgs into even partitions, 11 into odd partitions
+//        produceRecords(numberOfMsgsPerPartition, 0);
+//        produceRecords(numberOfMsgsPerPartition + 1, 1);
+//        produceRecords(numberOfMsgsPerPartition, 2);
+//        produceRecords(numberOfMsgsPerPartition + 1, 3);
+//
+//        // Some initial setup
+//        final List<ConsumerPartition> expectedPartitions;
+//        if (taskIndex == 0) {
+//            // If we're consumerIndex 0, we expect partitionIds 0 or 1
+//            expectedPartitions = Lists.newArrayList(partition0 , partition1);
+//        } else if (taskIndex == 1) {
+//            // If we're consumerIndex 0, we expect partitionIds 2 or 3
+//            expectedPartitions = Lists.newArrayList(partition2 , partition3);
+//        } else {
+//            throw new RuntimeException("Invalid input to test");
+//        }
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Create topology context, set our task index
+//        MockTopologyContext topologyContext = new MockTopologyContext();
+//        topologyContext.taskId = taskIndex;
+//        topologyContext.taskIndex = taskIndex;
+//
+//        // Say that we have 2 tasks, ids 0 and 1
+//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
+//
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Wait for our virtual spout to start
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
+//
+//        // Validate they all came from the correct partitions
+//        for (SpoutEmission spoutEmission : spoutEmissions) {
+//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+//
+//            // Validate it came from the right place
+//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+//        }
+//
+//        // Validate we don't have any other emissions
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+//
+//        // Lets ack our tuples
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Close
+//        spout.close();
+//    }
+//
+//    /**
+//     * This is an integration test of multiple SidelineConsumers.
+//     * We stand up a namespace with 4 partitions.
+//     * We then have a consumer size of 2.
+//     * We run the test once using consumerIndex 0
+//     *   - Verify we only consume from partitions 0 and 1
+//     * We run the test once using consumerIndex 1
+//     *   - Verify we only consume from partitions 2 and 3
+//     * @param taskIndex What taskIndex to run the test with.
+//     */
+//    @Test
+//    @UseDataProvider("providerOfTaskIds")
+//    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
+//        final int numberOfMsgsPerPartition = 10;
+//
+//        // Create a namespace with 4 partitions
+//        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
+//        getKafkaTestServer().createTopic(topicName, 5);
+//
+//        // Define some topicPartitions
+//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+//        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
+//
+//        // produce 10 msgs into even partitions, 11 into odd partitions
+//        produceRecords(numberOfMsgsPerPartition, 0);
+//        produceRecords(numberOfMsgsPerPartition + 1, 1);
+//        produceRecords(numberOfMsgsPerPartition, 2);
+//        produceRecords(numberOfMsgsPerPartition + 1, 3);
+//        produceRecords(numberOfMsgsPerPartition, 4);
+//
+//        // Some initial setup
+//        final List<ConsumerPartition> expectedPartitions;
+//        final int expectedNumberOfTuplesToConsume;
+//        if (taskIndex == 0) {
+//            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
+//            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
+//
+//            // We expect to get out 31 tuples
+//            expectedNumberOfTuplesToConsume = 31;
+//        } else if (taskIndex == 1) {
+//            // If we're consumerIndex 0, we expect partitionIds 3 or 4
+//            expectedPartitions = Lists.newArrayList(partition3 , partition4);
+//
+//            // We expect to get out 21 tuples
+//            expectedNumberOfTuplesToConsume = 21;
+//        } else {
+//            throw new RuntimeException("Invalid input to test");
+//        }
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Create topology context, set our task index
+//        MockTopologyContext topologyContext = new MockTopologyContext();
+//        topologyContext.taskId = taskIndex;
+//        topologyContext.taskIndex = taskIndex;
+//
+//        // Say that we have 2 tasks, ids 0 and 1
+//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
+//
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Wait for our virtual spout to start
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
+//
+//        // Validate they all came from the correct partitions
+//        for (SpoutEmission spoutEmission : spoutEmissions) {
+//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+//
+//            // Validate it came from the right place
+//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+//        }
+//
+//        // Validate we don't have any other emissions
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+//
+//        // Lets ack our tuples
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Close
+//        spout.close();
+//    }
+//
+//    /**
+//     * Provides task ids 0 and 1.
+//     */
+//    @DataProvider
+//    public static Object[][] providerOfTaskIds() {
+//        return new Object[][]{
+//            {0},
+//            {1}
+//        };
+//    }
+//
+//    /**
+//     * Tests that pending errors get reported via OutputCollector.
+//     */
+//    @Test
+//    public void testReportErrors() {
+//        // Define config
+//        Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
+//        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
+//
+//        // Create mocks
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector mockSpoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout
+//        final DynamicSpout spout = new DynamicSpout(config);
+//
+//        // Call open
+//        spout.open(config, topologyContext, mockSpoutOutputCollector);
+//
+//        // Hook into error queue, and queue some errors
+//        final Throwable exception1 = new RuntimeException("My RuntimeException");
+//        final Throwable exception2 = new Exception("My Exception");
+//
+//        // "Report" our exceptions
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//        messageBus.publishError(exception1);
+//        messageBus.publishError(exception2);
+//
+//        // Call next tuple a couple times, validate errors get reported.
+//        await()
+//            .atMost(30, TimeUnit.SECONDS)
+//            .until(() -> {
+//                // Call next tuple
+//                spout.nextTuple();
+//
+//                return mockSpoutOutputCollector.getReportedErrors().size() >= 2;
+//            });
+//
+//        // Validate
+//        final List<Throwable> reportedErrors = mockSpoutOutputCollector.getReportedErrors();
+//        assertEquals("Should have 2 reported errors", 2, reportedErrors.size());
+//        assertTrue("Contains first exception", reportedErrors.contains(exception1));
+//        assertTrue("Contains second exception", reportedErrors.contains(exception2));
+//
+//        // Call close
+//        spout.close();
+//    }
+//
+//    /**
+//     * Verifies that you do not define an output stream via the SidelineSpoutConfig
+//     * declareOutputFields() method with default to using 'default' stream.
+//     */
+//    @Test
+//    @UseDataProvider("provideOutputFields")
+//    public void testDeclareOutputFields_without_stream(final Object inputFields, final String[] expectedFields) {
+//        // Create config with null stream id config option.
+//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
+//
+//        // Define our output fields as key and value.
+//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
+//
+//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+//
+//        // Create spout, but don't call open
+//        final SidelineSpout spout = new SidelineSpout(config);
+//
+//        // call declareOutputFields
+//        spout.declareOutputFields(declarer);
+//
+//        // Validate results.
+//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+//
+//        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
+//        assertEquals(
+//            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
+//            Lists.newArrayList(expectedFields)
+//        );
+//
+//        spout.close();
+//    }
+//
+//    /**
+//     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
+//     * in the declareOutputFields() method.
+//     */
+//    @Test
+//    @UseDataProvider("provideOutputFields")
+//    public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
+//        final String streamId = "foobar";
+//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
+//
+//        // Define our output fields as key and value.
+//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
+//
+//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+//
+//        // Create spout, but do not call open.
+//        final SidelineSpout spout = new SidelineSpout(config);
+//
+//        // call declareOutputFields
+//        spout.declareOutputFields(declarer);
+//
+//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+//
+//        assertTrue(fieldsDeclaration.containsKey(streamId));
+//        assertEquals(
+//            fieldsDeclaration.get(streamId).get_output_fields(),
+//            Lists.newArrayList(expectedFields)
+//        );
+//
+//        spout.close();
+//    }
+//
+//    /**
+//     * Provides various inputs to be split.
+//     */
+//    @DataProvider
+//    public static Object[][] provideOutputFields() throws InstantiationException, IllegalAccessException {
+//        return new Object[][] {
+//            // String inputs, these get split and trimmed.
+//            { "key,value", new String[] {"key", "value"} },
+//            { "key, value", new String[] {"key", "value"} },
+//            { " key    , value  ,", new String[] {"key", "value"} },
+//
+//            // List of Strings, used as is.
+//            { Lists.newArrayList("key", "value"), new String[] { "key", "value"} },
+//            { Lists.newArrayList("  key  ", " value"), new String[] { "  key  ", " value"} },
+//            { Lists.newArrayList("key,value", "another"), new String[] { "key,value", "another"} },
+//
+//            // Fields inputs, used as is.
+//            { new Fields("key", "value"), new String[] { "key", "value" } },
+//            { new Fields(" key ", "    value"), new String[] { " key ", "    value" } },
+//            { new Fields("key,value ", "another"), new String[] { "key,value ", "another" } },
+//        };
+//    }
+//
+//    /**
+//     * Noop, just doing coverage!  These methods don't actually
+//     * do anything right now anyways.
+//     */
+//    @Test
+//    public void testActivate() {
+//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+//        spout.activate();
+//    }
+//
+//    /**
+//     * Noop, just doing coverage!  These methods don't actually
+//     * do anything right now anyways.
+//     */
+//    @Test
+//    public void testDeactivate() {
+//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+//        spout.deactivate();
+//    }
+//
+//    // Helper methods
+//
+//    /**
+//     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
+//     * got emitted by the spout, and make sure everything matches up to what we expected.
+//     *
+//     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
+//     * @param spoutEmission - The SpoutEmissions we got out of the spout
+//     * @param expectedConsumerId - What consumerId these emissions should be associated with.
+//     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
+//     */
+//    private void validateEmission(
+//        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
+//        final SpoutEmission spoutEmission,
+//        final String expectedConsumerId,
+//        final String expectedOutputStreamId
+//    ) {
+//        // Now find its corresponding tuple
+//        assertNotNull("Not null sanity check", spoutEmission);
+//        assertNotNull("Not null sanity check", sourceProducerRecord);
+//
+//        // Validate Message Id
+//        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
+//        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
+//
+//        // Grab the messageId and validate it
+//        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
+//        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
+//        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
+//
+//        // TODO: Should revisit this and refactor the test to properly pass around identifiers for validation
+//        assertEquals("Expected Source Consumer Id", expectedConsumerId, messageId.getSrcVirtualSpoutId().toString());
+//
+//        // Validate Tuple Contents
+//        List<Object> tupleValues = spoutEmission.getTuple();
+//        assertNotNull("Tuple Values should not be null", tupleValues);
+//        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
+//
+//        // For now the values in the tuple should be 'key' and 'value', this may change.
+//        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
+//        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
+//        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
+//
+//        // Validate Emit Parameters
+//        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
+//    }
+//
+//    /**
+//     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
+//     * to actually ack them before returning.
+//     *
+//     * @param spout - the Spout instance to ack tuples on.
+//     * @param spoutEmissions - The SpoutEmissions we want to ack.
+//     */
+//    private void ackTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+//        if (spoutEmissions.isEmpty()) {
+//            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
+//        }
+//
+//        // Ack each one.
+//        for (SpoutEmission emission: spoutEmissions) {
+//            spout.ack(emission.getMessageId());
+//        }
+//
+//        // Grab reference to message bus.
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//
+//        // Acking tuples is an async process, so we need to make sure they get picked up
+//        // and processed before continuing.
+//        await()
+//            .atMost(6500, TimeUnit.MILLISECONDS)
+//            .until(() -> {
+//                // Wait for our tuples to get popped off the acked queue.
+//                return messageBus.ackSize() == 0;
+//            }, equalTo(true));
+//    }
+//
+//    /**
+//     * Utility method to fail tuples on a spout.  This will wait for the underlying VirtualSpout instance
+//     * to actually fail them before returning.
+//     *
+//     * @param spout - the Spout instance to ack tuples on.
+//     * @param spoutEmissions - The SpoutEmissions we want to ack.
+//     */
+//    private void failTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+//        if (spoutEmissions.isEmpty()) {
+//            throw new RuntimeException("You cannot fail an empty list!  You probably have a bug in your test.");
+//        }
+//
+//        // Fail each one.
+//        for (SpoutEmission emission: spoutEmissions) {
+//            spout.fail(emission.getMessageId());
+//        }
+//
+//        // Grab reference to message bus.
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//
+//        // Failing tuples is an async process, so we need to make sure they get picked up
+//        // and processed before continuing.
+//        await()
+//            .atMost(6500, TimeUnit.MILLISECONDS)
+//            .until(() -> {
+//                // Wait for our tuples to get popped off the fail queue.
+//                return messageBus.failSize() == 0;
+//            }, equalTo(true));
+//    }
+//
+//    /**
+//     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
+//     * @param spout - The spout instance to call nextTuple() on.
+//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+//     * @param numberOfAttempts - How many times to call nextTuple()
+//     */
+//    private void validateNextTupleEmitsNothing(
+//        DynamicSpout spout,
+//        MockSpoutOutputCollector collector,
+//        int numberOfAttempts,
+//        long delayInMs
+//    ) {
+//        try {
+//            Thread.sleep(delayInMs);
+//        } catch (InterruptedException e) {
+//            throw new RuntimeException(e);
+//        }
+//
+//        // Try a certain number of times
+//        final int originalSize = collector.getEmissions().size();
+//        for (int x = 0; x < numberOfAttempts; x++) {
+//            // Call next Tuple
+//            spout.nextTuple();
+//
+//            // If we get an unexpected emission
+//            if (originalSize != collector.getEmissions().size()) {
+//                // Lets log it
+//                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
+//            }
+//            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
+//        }
+//    }
+//
+//    /**
+//     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
+//     * @param spout - The spout instance to call nextTuple() on.
+//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+//     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
+//     */
+//    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
+//        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
+//
+//        // Create a new list for the emissions we expect to get back
+//        List<SpoutEmission> newEmissions = Lists.newArrayList();
+//
+//        // Determine how many emissions are already in the collector
+//        final int existingEmissionsCount = collector.getEmissions().size();
+//
+//        // Call next tuple N times
+//        for (int x = 0; x < numberOfTuples; x++) {
+//            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
+//            await()
+//                .atMost(5, TimeUnit.SECONDS)
+//                .until(() -> {
+//                    // Ask for next tuple
+//                    spout.nextTuple();
+//
+//                    // Return how many tuples have been emitted so far
+//                    // It should be equal to our loop count + 1
+//                    return collector.getEmissions().size();
+//                }, equalTo(existingEmissionsCount + x + 1));
+//
+//            // Should have some emissions
+//            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
+//
+//            // Add our new emission to our return list
+//            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
+//        }
+//
+//        // Log them for reference.
+//        logger.info("Found new emissions: {}", newEmissions);
+//        return newEmissions;
+//    }
+//
+//    /**
+//     * Given a list of produced kafka messages, and a list of tuples that got emitted,
+//     * make sure that the tuples match up with what we expected to get sent out.
+//     *  @param producedRecords the original records produced into kafka.
+//     * @param spoutEmissions the tuples that got emitted out from the spout
+//     * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
+//     * @param expectedConsumerId consumer id we expected
+//     */
+//    private void validateTuplesFromSourceMessages(
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
+//        final List<SpoutEmission> spoutEmissions,
+//        final String expectedStreamId,
+//        final String expectedConsumerId
+//    ) {
+//        // Sanity check, make sure we have the same number of each.
+//        assertEquals(
+//            "Should have same number of tuples as original messages, Produced Count: " + producedRecords.size()
+//                + " Emissions Count: " + spoutEmissions.size(),
+//            producedRecords.size(),
+//            spoutEmissions.size()
+//        );
+//
+//        // Iterator over what got emitted
+//        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
+//
+//        // Loop over what we produced into kafka
+//        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
+//            // Now find its corresponding tuple from our iterator
+//            final SpoutEmission spoutEmission = emissionIterator.next();
+//
+//            // validate that they match
+//            validateEmission(producedRecord, spoutEmission, expectedConsumerId, expectedStreamId);
+//        }
+//    }
+//
+//    /**
+//     * Waits for virtual spouts to close out.
+//     * @param spout - The spout instance
+//     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
+//     */
+//    private void waitForVirtualSpouts(DynamicSpout spout, int howManyVirtualSpoutsWeWantLeft) {
+//        await()
+//            .atMost(5, TimeUnit.SECONDS)
+//            .until(() -> spout.getSpoutCoordinator().getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
+//        assertEquals(
+//            "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
+//            howManyVirtualSpoutsWeWantLeft,
+//            spout.getSpoutCoordinator().getTotalSpouts()
+//        );
+//    }
+
+    /**
+     * helper method to produce records into kafka.
+     */
+    private List<ProducedKafkaRecord<byte[], byte[]>> produceRecords(int numberOfRecords, int partitionId) {
+        KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
+        return kafkaTestUtils.produceRecords(numberOfRecords, topicName, partitionId);
+    }
+
+    /**
+     * Generates a Storm Topology configuration with some sane values for our test scenarios.
+     *
+     * @param consumerIdPrefix - consumerId prefix to use.
+     * @param configuredStreamId - What streamId we should emit tuples out of.
+     */
+    private Map<String, Object> getDefaultConfig(final String consumerIdPrefix, final String configuredStreamId) {
+        // Generate a unique zkRootNode for each test
+        final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
+
+        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
+
+        // Kafka Consumer config items
+        config.put(SpoutConfig.CONSUMER_CLASS, Consumer.class.getName());
+        config.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
+        config.put(KafkaConsumerConfig.KAFKA_TOPIC, topicName);
+        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, consumerIdPrefix);
+        config.put(KafkaConsumerConfig.KAFKA_BROKERS, Lists.newArrayList(getKafkaTestServer().getKafkaConnectString()));
+
+        // DynamicSpout config items
+        config.put(SpoutConfig.RETRY_MANAGER_CLASS, NeverRetryManager.class.getName());
+        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
+        config.put(SpoutConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
+
+        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
+
+        // TODO: Separate the dependencies on this from this test!!!
+        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
+        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
+        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        config.put(
+            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
+        );
+
+        // Configure SpoutCoordinator thread to run every 1 second
+        config.put(SpoutConfig.MONITOR_THREAD_INTERVAL_MS, 1000L);
+
+        // Configure flushing consumer state every 1 second
+        config.put(SpoutConfig.CONSUMER_STATE_FLUSH_INTERVAL_MS, 1000L);
+
+        // For now use the Log Recorder
+        config.put(SpoutConfig.METRICS_RECORDER_CLASS, LogRecorder.class.getName());
+
+        config.put(SpoutConfig.SPOUT_HANDLER_CLASS, SidelineSpoutHandler.class.getName());
+
+        config.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
+
+        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
+
+        // If we have a stream Id we should be configured with
+        if (configuredStreamId != null) {
+            // Drop it into our configuration.
+            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
+        }
+
+        return config;
+    }
+
+    /**
+     * Provides various StreamIds to test emitting out of.
+     */
+    @DataProvider
+    public static Object[][] provideStreamIds() {
+        return new Object[][]{
+            // No explicitly defined streamId should use the default streamId.
+            { null, Utils.DEFAULT_STREAM_ID },
+
+            // Explicitly defined streamId should get used as is.
+            { "SpecialStreamId", "SpecialStreamId" }
+        };
+    }
+
+    /**
+     * Simple accessor.
+     */
+    private KafkaTestServer getKafkaTestServer() {
+        return sharedKafkaTestResource.getKafkaTestServer();
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/KafkaConsumerSpoutTest.java
@@ -1,5 +1,31 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.salesforce.storm.spout.dynamic;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.salesforce.kafka.test.KafkaTestServer;
@@ -11,30 +37,48 @@ import com.salesforce.storm.spout.dynamic.kafka.Consumer;
 import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
 import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
+import com.salesforce.storm.spout.dynamic.mocks.MockTopologyContext;
+import com.salesforce.storm.spout.dynamic.mocks.output.MockSpoutOutputCollector;
+import com.salesforce.storm.spout.dynamic.mocks.output.SpoutEmission;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
+import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
+import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
 import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
-import com.salesforce.storm.spout.sideline.SidelineSpoutTest;
-import com.salesforce.storm.spout.sideline.config.SidelineConfig;
-import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
-import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
-import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
 import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.utils.Utils;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.time.Clock;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
- *
+ * Provides End-To-End integration testing of DynamicSpout + Kafka Consumer.
+ * This test does not attempt to validate DynamicSpout's behavior that is covered by DynamicSpoutTest.
  */
+@RunWith(DataProviderRunner.class)
 public class KafkaConsumerSpoutTest {
     // For logging within the test.
-    private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(KafkaConsumerSpoutTest.class);
 
     /**
      * Create shared kafka test server.
@@ -54,1246 +98,818 @@ public class KafkaConsumerSpoutTest {
     @Before
     public void beforeTest() throws InterruptedException {
         // Generate namespace name
-        topicName = SidelineSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
+        topicName = KafkaConsumerSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
 
         // Create namespace
         getKafkaTestServer().createTopic(topicName);
     }
 
-//    /**
-//     * Our most simple end-2-end test.
-//     * This test stands up our spout and ask it to consume from our kafka namespace.
-//     * We publish some data into kafka, and validate that when we call nextTuple() on
-//     * our spout that we get out our messages that were published into kafka.
-//     *
-//     * This does not make use of any side lining logic, just simple consuming from the
-//     * 'fire hose' consumer.
-//     *
-//     * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
-//     * output stream name (default), as well as an explicitly configured stream name.
-//     */
-//    @Test
-//    @UseDataProvider("provideStreamIds")
-//    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
-//        // Define how many tuples we should push into the namespace, and then consume back out.
-//        final int emitTupleCount = 10;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
-//
-//        // If we have a stream Id we should be configured with
-//        if (configuredStreamId != null) {
-//            // Drop it into our configuration.
-//            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
-//        }
-//
-//        // Some mock storm topology stuff to get going
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple, namespace is empty, so nothing should get emitted.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
-//
-//        // Lets produce some data into the namespace
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
-//
-//        // Now consume tuples generated from the messages we published into kafka.
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//
-//        // Validate the tuples that got emitted are what we expect based on what we published into kafka
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Call next tuple a few more times to make sure nothing unexpected shows up.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
-//
-//        // Cleanup.
-//        spout.close();
-//    }
-//
-//    /**
-//     * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
-//     * retry manager.
-//     *
-//     * This test stands up our spout and ask it to consume from our kafka namespace.
-//     * We publish some data into kafka, and validate that when we call nextTuple() on
-//     * our spout that we get out our messages that were published into kafka.
-//     *
-//     * We then fail some tuples and validate that they get replayed.
-//     * We ack some tuples and then validate that they do NOT get replayed.
-//     *
-//     * This does not make use of any side lining logic, just simple consuming from the
-//     * 'fire hose' namespace.
-//     */
-//    @Test
-//    public void doBasicFailTest() throws InterruptedException {
-//        // Define how many tuples we should push into the namespace, and then consume back out.
-//        final int emitTupleCount = 10;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "SidelineSpout";
-//
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Configure to use our FailedTuplesFirstRetryManager retry manager.
-//        config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
-//
-//        // Some mock stuff to get going
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple, namespace is empty, so should get nothing.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Lets produce some data into the namespace
-//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
-//
-//        // Now loop and get our tuples
-//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//
-//        // Now lets validate that what we got out of the spout is what we actually expected.
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Call next tuple a few more times to make sure nothing unexpected shows up.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Now lets fail our tuples.
-//        failTuples(spout, spoutEmissions);
-//
-//        // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
-//        // And our retry manager should replay them first chance it gets.
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Now lets ack 2 different offsets, entries 0 and 3.
-//        // This means they should never get replayed.
-//        List<SpoutEmission> ackedEmissions = Lists.newArrayList();
-//        ackedEmissions.add(spoutEmissions.get(0));
-//        ackedEmissions.add(spoutEmissions.get(3));
-//        ackTuples(spout, ackedEmissions);
-//
-//        // And lets remove their related KafkaRecords
-//        // Remember to remove in reverse order, because ArrayLists have no gaps in indexes :p
-//        producedRecords.remove(3);
-//        producedRecords.remove(0);
-//
-//        // And lets fail the others
-//        List<SpoutEmission> failEmissions = Lists.newArrayList(spoutEmissions);
-//        failEmissions.removeAll(ackedEmissions);
-//        failTuples(spout, failEmissions);
-//
-//        // This is how many we failed.
-//        final int failedTuples = failEmissions.size();
-//
-//        // If we call nextTuple, we should get back our failed emissions
-//        final List<SpoutEmission> replayedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, failedTuples);
-//
-//        // Validate we don't get anything else
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate the replayed tuples were our failed ones
-//        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Now lets ack these
-//        ackTuples(spout, replayedEmissions);
-//
-//        // And validate nextTuple gives us nothing new
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Cleanup.
-//        spout.close();
-//    }
-//
-//    /**
-//     * Our most basic End 2 End test that includes basic sidelining.
-//     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
-//     * Records 1 and 2 we get out of the spout.
-//     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
-//     * We stop sidelining, this should cause a virtual spout to be started within the spout.
-//     * Calling nextTuple() should get back the records that were previously skipped.
-//     * We produce additional records into the namespace.
-//     * Call nextTuple() and we should get them out.
-//     */
-//    @Test
-//    public void doTestWithSidelining() throws InterruptedException {
-//        // How many records to publish into kafka per go.
-//        final int numberOfRecordsToPublish = 3;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//
-//        // Create our Config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Create some stand-in mocks.
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Produce records into kafka
-//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-//        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
-//        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
-//        // to be emitted.
-//        // Grab out the emissions so we can validate them.
-//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // Validate the tuples are what we published into kafka
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
-//        assertEquals("Should have a single VirtualSpout instance", 1, spout.getSpoutCoordinator().getTotalSpouts());
-//
-//        // Create a static message filter, this allows us to easily start filtering messages.
-//        // It should filter ALL messages
-//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-//
-//        // Send a new start request with our filter.
-//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-//        StaticTrigger.sendStartRequest(request);
-//
-//        // Produce another 3 records into kafka.
-//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // We basically want the time that would normally pass before we check that there are no new tuples
-//        // Call next tuple, it should NOT receive any tuples because
-//        // all tuples are filtered.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-//
-//        // Send a stop sideline request
-//        StaticTrigger.sendStopRequest(request);
-//
-//        // We need to wait a bit for the sideline spout instance to spin up
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Then ask the spout for tuples, we should get back the tuples that were produced while
-//        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // We should validate these emissions
-//        validateTuplesFromSourceMessages(
-//            producedRecords,
-//            spoutEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":sideline:" + request.id
-//        );
-//
-//        // Call next tuple a few more times to be safe nothing else comes in.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
-//        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
-//        assertEquals("We should have 2 virtual spouts running", 2, spout.getSpoutCoordinator().getTotalSpouts());
-//
-//        // Lets ack our messages.
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
-//        // We need to wait for the monitor thread to run to clean it up.
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Produce some more records, verify they come in the firehose.
-//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // Loop over what we produced into kafka and validate them
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Close out
-//        spout.close();
-//    }
-//
-//    /**
-//     * This test stands up a spout instance and begins consuming from a namespace.
-//     * Halfway thru consuming all the messages published in that namespace we will shutdown
-//     * the spout gracefully.
-//     *
-//     * We'll create a new instance of the spout and fire it up, then validate that it resumes
-//     * consuming from where it left off.
-//     *
-//     * Assumptions made in this test:
-//     *   - single partition namespace
-//     *   - using ZK persistence manager to maintain state between spout instances/restarts.
-//     */
-//    @Test
-//    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException, KeeperException {
-//        // Produce 10 messages into kafka (offsets 0->9)
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Some mock stuff to get going
-//        TopologyContext topologyContext = new MockTopologyContext();
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
-//        final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
-//
-//        // Validate its the messages we expected
-//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // We will ack offsets in the following order: 2,0,1,3,5
-//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // Create fresh new spoutOutputCollector & topology context
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create fresh new instance of spout & call open all with the same config
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Call next tuple to get remaining tuples out.
-//        // It should give us offsets [4,5,6,7,8,9]
-//        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
-//            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
-//        );
-//
-//        // Validate no further tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate its the tuples we expect [4,5,6,7,8,9]
-//        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // Ack all tuples.
-//        ackTuples(spout, spoutEmissionsAfterResume);
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // Create fresh new spoutOutputCollector & topology context
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create fresh new instance of spout & call open all with the same config
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Validate no further tuples, as we acked all the things.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-//
-//        // And done.
-//        spout.close();
-//    }
-//
-//    /**
-//     * This test stands up a spout instance and tests sidelining.
-//     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
-//     * we stop the spout, create a new instance and restart it.  If things are working correctly
-//     * the sidelined VirtualSpout should resume from where it left off.
-//     */
-//    @Test
-//    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
-//        // Produce 10 messages into kafka (offsets 0->9)
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//        config.put(
-//            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-//            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
-//        );
-//
-//        // Some mock stuff to get going
-//        TopologyContext topologyContext = new MockTopologyContext();
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
-//
-//        // Validate its the messages we expected
-//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // We will ack offsets in the following order: 2,0,1,3,5
-//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
-//
-//        // Create a static message filter, this allows us to easily start filtering messages.
-//        // It should filter ALL messages
-//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-//
-//        // Send a new start request with our filter.
-//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-//        StaticTrigger.sendStartRequest(request);
-//
-//        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
-//
-//        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
-//        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
-//
-//        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
-//        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
-//
-//        // We'll validate them
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
-//
-//        // Lets not ack any more tuples from the fire hose, that means the last completed
-//        // offset on the fire hose spout should still be 3.
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout again");
-//        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
-//
-//        // Create new Spout instance and start
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Wait 3 seconds, then verify we have a single virtual spouts running
-//        Thread.sleep(3000L);
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
-//        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
-//
-//        // Send a stop sideline request
-//        StaticTrigger.sendStopRequest(request);
-//
-//        // Verify 2 VirtualSpouts are running
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Call nextTuple() 3 times
-//        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-//
-//        // Verify we get offsets [4,5,6] by validating the tuples
-//        validateEmission(
-//            producedRecords.get(4),
-//            sidelinedEmissions.get(0),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//        validateEmission(
-//            producedRecords.get(5),
-//            sidelinedEmissions.get(1),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//        validateEmission(
-//            producedRecords.get(6),
-//            sidelinedEmissions.get(2),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//
-//        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
-//        ackTuples(spout, sidelinedEmissions);
-//
-//        // Shut down spout.
-//        spout.close();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout again");
-//        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
-//
-//        // Create new spout instance and start
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Verify we have a 2 virtual spouts running
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Since last committed offset should be 6,
-//        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
-//        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
-//
-//        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
-//        // Gather up the expected records
-//        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
-//        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
-//        sidelineKafkaRecords.addAll(additionalProducedRecords);
-//
-//        // Validate em.
-//        validateTuplesFromSourceMessages(
-//            sidelineKafkaRecords,
-//            sidelinedEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier
-//        );
-//
-//        // call nextTuple() several times, get nothing back
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
-//        ackTuples(spout, sidelinedEmissions);
-//
-//        // Verify 2nd VirtualSpout shuts off
-//        waitForVirtualSpouts(spout, 1);
-//        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
-//
-//        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
-//        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
-//
-//        // Call nextTuple() 5 times,
-//        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
-//
-//        // verify we get the tuples [15,16,17,18,19]
-//        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Ack offsets [15,16,18] => Committed offset should be 16
-//        ackTuples(spout, Lists.newArrayList(
-//            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
-//        ));
-//
-//        // Verify no more tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Stop spout
-//        spout.close();
-//
-//        // Create new spout instance and start.
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout for last time");
-//        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
-//
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Verify we have a single 1 virtual spouts running,
-//        // This makes sure that we don't resume a previously completed sideline request.
-//        Thread.sleep(3000);
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call nextTuple() 3 times,
-//        // verify we get offsets [17,18,19]
-//        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-//
-//        // Validate we got the right offset [17,18,19]
-//        validateTuplesFromSourceMessages(
-//            lastProducedRecords.subList(2,5),
-//            lastSpoutEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":main"
-//        );
-//
-//        // Verify no more tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Stop spout.
-//        spout.close();
-//    }
-//
-//    /**
-//     * This is an integration test of multiple SidelineConsumers.
-//     * We stand up a namespace with 4 partitions.
-//     * We then have a consumer size of 2.
-//     * We run the test once using consumerIndex 0
-//     *   - Verify we only consume from partitions 0 and 1
-//     * We run the test once using consumerIndex 1
-//     *   - Verify we only consume from partitions 2 and 3
-//     * @param taskIndex What taskIndex to run the test with.
-//     */
-//    @Test
-//    @UseDataProvider("providerOfTaskIds")
-//    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
-//        final int numberOfMsgsPerPartition = 10;
-//
-//        // Create a namespace with 4 partitions
-//        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
-//        getKafkaTestServer().createTopic(topicName, 4);
-//
-//        // Define some topicPartitions
-//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-//
-//        // produce 10 msgs into even partitions, 11 into odd partitions
-//        produceRecords(numberOfMsgsPerPartition, 0);
-//        produceRecords(numberOfMsgsPerPartition + 1, 1);
-//        produceRecords(numberOfMsgsPerPartition, 2);
-//        produceRecords(numberOfMsgsPerPartition + 1, 3);
-//
-//        // Some initial setup
-//        final List<ConsumerPartition> expectedPartitions;
-//        if (taskIndex == 0) {
-//            // If we're consumerIndex 0, we expect partitionIds 0 or 1
-//            expectedPartitions = Lists.newArrayList(partition0 , partition1);
-//        } else if (taskIndex == 1) {
-//            // If we're consumerIndex 0, we expect partitionIds 2 or 3
-//            expectedPartitions = Lists.newArrayList(partition2 , partition3);
-//        } else {
-//            throw new RuntimeException("Invalid input to test");
-//        }
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Create topology context, set our task index
-//        MockTopologyContext topologyContext = new MockTopologyContext();
-//        topologyContext.taskId = taskIndex;
-//        topologyContext.taskIndex = taskIndex;
-//
-//        // Say that we have 2 tasks, ids 0 and 1
-//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-//
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Wait for our virtual spout to start
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
-//
-//        // Validate they all came from the correct partitions
-//        for (SpoutEmission spoutEmission : spoutEmissions) {
-//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
-//
-//            // Validate it came from the right place
-//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
-//        }
-//
-//        // Validate we don't have any other emissions
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
-//
-//        // Lets ack our tuples
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Close
-//        spout.close();
-//    }
-//
-//    /**
-//     * This is an integration test of multiple SidelineConsumers.
-//     * We stand up a namespace with 4 partitions.
-//     * We then have a consumer size of 2.
-//     * We run the test once using consumerIndex 0
-//     *   - Verify we only consume from partitions 0 and 1
-//     * We run the test once using consumerIndex 1
-//     *   - Verify we only consume from partitions 2 and 3
-//     * @param taskIndex What taskIndex to run the test with.
-//     */
-//    @Test
-//    @UseDataProvider("providerOfTaskIds")
-//    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
-//        final int numberOfMsgsPerPartition = 10;
-//
-//        // Create a namespace with 4 partitions
-//        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
-//        getKafkaTestServer().createTopic(topicName, 5);
-//
-//        // Define some topicPartitions
-//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-//        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
-//
-//        // produce 10 msgs into even partitions, 11 into odd partitions
-//        produceRecords(numberOfMsgsPerPartition, 0);
-//        produceRecords(numberOfMsgsPerPartition + 1, 1);
-//        produceRecords(numberOfMsgsPerPartition, 2);
-//        produceRecords(numberOfMsgsPerPartition + 1, 3);
-//        produceRecords(numberOfMsgsPerPartition, 4);
-//
-//        // Some initial setup
-//        final List<ConsumerPartition> expectedPartitions;
-//        final int expectedNumberOfTuplesToConsume;
-//        if (taskIndex == 0) {
-//            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
-//            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
-//
-//            // We expect to get out 31 tuples
-//            expectedNumberOfTuplesToConsume = 31;
-//        } else if (taskIndex == 1) {
-//            // If we're consumerIndex 0, we expect partitionIds 3 or 4
-//            expectedPartitions = Lists.newArrayList(partition3 , partition4);
-//
-//            // We expect to get out 21 tuples
-//            expectedNumberOfTuplesToConsume = 21;
-//        } else {
-//            throw new RuntimeException("Invalid input to test");
-//        }
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Create topology context, set our task index
-//        MockTopologyContext topologyContext = new MockTopologyContext();
-//        topologyContext.taskId = taskIndex;
-//        topologyContext.taskIndex = taskIndex;
-//
-//        // Say that we have 2 tasks, ids 0 and 1
-//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-//
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Wait for our virtual spout to start
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
-//
-//        // Validate they all came from the correct partitions
-//        for (SpoutEmission spoutEmission : spoutEmissions) {
-//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
-//
-//            // Validate it came from the right place
-//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
-//        }
-//
-//        // Validate we don't have any other emissions
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
-//
-//        // Lets ack our tuples
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Close
-//        spout.close();
-//    }
-//
-//    /**
-//     * Provides task ids 0 and 1.
-//     */
-//    @DataProvider
-//    public static Object[][] providerOfTaskIds() {
-//        return new Object[][]{
-//            {0},
-//            {1}
-//        };
-//    }
-//
-//    /**
-//     * Tests that pending errors get reported via OutputCollector.
-//     */
-//    @Test
-//    public void testReportErrors() {
-//        // Define config
-//        Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-//        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
-//
-//        // Create mocks
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector mockSpoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout
-//        final DynamicSpout spout = new DynamicSpout(config);
-//
-//        // Call open
-//        spout.open(config, topologyContext, mockSpoutOutputCollector);
-//
-//        // Hook into error queue, and queue some errors
-//        final Throwable exception1 = new RuntimeException("My RuntimeException");
-//        final Throwable exception2 = new Exception("My Exception");
-//
-//        // "Report" our exceptions
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//        messageBus.publishError(exception1);
-//        messageBus.publishError(exception2);
-//
-//        // Call next tuple a couple times, validate errors get reported.
-//        await()
-//            .atMost(30, TimeUnit.SECONDS)
-//            .until(() -> {
-//                // Call next tuple
-//                spout.nextTuple();
-//
-//                return mockSpoutOutputCollector.getReportedErrors().size() >= 2;
-//            });
-//
-//        // Validate
-//        final List<Throwable> reportedErrors = mockSpoutOutputCollector.getReportedErrors();
-//        assertEquals("Should have 2 reported errors", 2, reportedErrors.size());
-//        assertTrue("Contains first exception", reportedErrors.contains(exception1));
-//        assertTrue("Contains second exception", reportedErrors.contains(exception2));
-//
-//        // Call close
-//        spout.close();
-//    }
-//
-//    /**
-//     * Verifies that you do not define an output stream via the SidelineSpoutConfig
-//     * declareOutputFields() method with default to using 'default' stream.
-//     */
-//    @Test
-//    @UseDataProvider("provideOutputFields")
-//    public void testDeclareOutputFields_without_stream(final Object inputFields, final String[] expectedFields) {
-//        // Create config with null stream id config option.
-//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
-//
-//        // Define our output fields as key and value.
-//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
-//
-//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-//
-//        // Create spout, but don't call open
-//        final SidelineSpout spout = new SidelineSpout(config);
-//
-//        // call declareOutputFields
-//        spout.declareOutputFields(declarer);
-//
-//        // Validate results.
-//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-//
-//        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
-//        assertEquals(
-//            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
-//            Lists.newArrayList(expectedFields)
-//        );
-//
-//        spout.close();
-//    }
-//
-//    /**
-//     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
-//     * in the declareOutputFields() method.
-//     */
-//    @Test
-//    @UseDataProvider("provideOutputFields")
-//    public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
-//        final String streamId = "foobar";
-//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
-//
-//        // Define our output fields as key and value.
-//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
-//
-//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-//
-//        // Create spout, but do not call open.
-//        final SidelineSpout spout = new SidelineSpout(config);
-//
-//        // call declareOutputFields
-//        spout.declareOutputFields(declarer);
-//
-//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-//
-//        assertTrue(fieldsDeclaration.containsKey(streamId));
-//        assertEquals(
-//            fieldsDeclaration.get(streamId).get_output_fields(),
-//            Lists.newArrayList(expectedFields)
-//        );
-//
-//        spout.close();
-//    }
-//
-//    /**
-//     * Provides various inputs to be split.
-//     */
-//    @DataProvider
-//    public static Object[][] provideOutputFields() throws InstantiationException, IllegalAccessException {
-//        return new Object[][] {
-//            // String inputs, these get split and trimmed.
-//            { "key,value", new String[] {"key", "value"} },
-//            { "key, value", new String[] {"key", "value"} },
-//            { " key    , value  ,", new String[] {"key", "value"} },
-//
-//            // List of Strings, used as is.
-//            { Lists.newArrayList("key", "value"), new String[] { "key", "value"} },
-//            { Lists.newArrayList("  key  ", " value"), new String[] { "  key  ", " value"} },
-//            { Lists.newArrayList("key,value", "another"), new String[] { "key,value", "another"} },
-//
-//            // Fields inputs, used as is.
-//            { new Fields("key", "value"), new String[] { "key", "value" } },
-//            { new Fields(" key ", "    value"), new String[] { " key ", "    value" } },
-//            { new Fields("key,value ", "another"), new String[] { "key,value ", "another" } },
-//        };
-//    }
-//
-//    /**
-//     * Noop, just doing coverage!  These methods don't actually
-//     * do anything right now anyways.
-//     */
-//    @Test
-//    public void testActivate() {
-//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-//        spout.activate();
-//    }
-//
-//    /**
-//     * Noop, just doing coverage!  These methods don't actually
-//     * do anything right now anyways.
-//     */
-//    @Test
-//    public void testDeactivate() {
-//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-//        spout.deactivate();
-//    }
-//
-//    // Helper methods
-//
-//    /**
-//     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
-//     * got emitted by the spout, and make sure everything matches up to what we expected.
-//     *
-//     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
-//     * @param spoutEmission - The SpoutEmissions we got out of the spout
-//     * @param expectedConsumerId - What consumerId these emissions should be associated with.
-//     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
-//     */
-//    private void validateEmission(
-//        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
-//        final SpoutEmission spoutEmission,
-//        final String expectedConsumerId,
-//        final String expectedOutputStreamId
-//    ) {
-//        // Now find its corresponding tuple
-//        assertNotNull("Not null sanity check", spoutEmission);
-//        assertNotNull("Not null sanity check", sourceProducerRecord);
-//
-//        // Validate Message Id
-//        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
-//        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
-//
-//        // Grab the messageId and validate it
-//        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
-//        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
-//        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
-//
-//        // TODO: Should revisit this and refactor the test to properly pass around identifiers for validation
-//        assertEquals("Expected Source Consumer Id", expectedConsumerId, messageId.getSrcVirtualSpoutId().toString());
-//
-//        // Validate Tuple Contents
-//        List<Object> tupleValues = spoutEmission.getTuple();
-//        assertNotNull("Tuple Values should not be null", tupleValues);
-//        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
-//
-//        // For now the values in the tuple should be 'key' and 'value', this may change.
-//        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
-//        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
-//        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
-//
-//        // Validate Emit Parameters
-//        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
-//    }
-//
-//    /**
-//     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
-//     * to actually ack them before returning.
-//     *
-//     * @param spout - the Spout instance to ack tuples on.
-//     * @param spoutEmissions - The SpoutEmissions we want to ack.
-//     */
-//    private void ackTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
-//        if (spoutEmissions.isEmpty()) {
-//            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
-//        }
-//
-//        // Ack each one.
-//        for (SpoutEmission emission: spoutEmissions) {
-//            spout.ack(emission.getMessageId());
-//        }
-//
-//        // Grab reference to message bus.
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//
-//        // Acking tuples is an async process, so we need to make sure they get picked up
-//        // and processed before continuing.
-//        await()
-//            .atMost(6500, TimeUnit.MILLISECONDS)
-//            .until(() -> {
-//                // Wait for our tuples to get popped off the acked queue.
-//                return messageBus.ackSize() == 0;
-//            }, equalTo(true));
-//    }
-//
-//    /**
-//     * Utility method to fail tuples on a spout.  This will wait for the underlying VirtualSpout instance
-//     * to actually fail them before returning.
-//     *
-//     * @param spout - the Spout instance to ack tuples on.
-//     * @param spoutEmissions - The SpoutEmissions we want to ack.
-//     */
-//    private void failTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
-//        if (spoutEmissions.isEmpty()) {
-//            throw new RuntimeException("You cannot fail an empty list!  You probably have a bug in your test.");
-//        }
-//
-//        // Fail each one.
-//        for (SpoutEmission emission: spoutEmissions) {
-//            spout.fail(emission.getMessageId());
-//        }
-//
-//        // Grab reference to message bus.
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//
-//        // Failing tuples is an async process, so we need to make sure they get picked up
-//        // and processed before continuing.
-//        await()
-//            .atMost(6500, TimeUnit.MILLISECONDS)
-//            .until(() -> {
-//                // Wait for our tuples to get popped off the fail queue.
-//                return messageBus.failSize() == 0;
-//            }, equalTo(true));
-//    }
-//
-//    /**
-//     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
-//     * @param spout - The spout instance to call nextTuple() on.
-//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
-//     * @param numberOfAttempts - How many times to call nextTuple()
-//     */
-//    private void validateNextTupleEmitsNothing(
-//        DynamicSpout spout,
-//        MockSpoutOutputCollector collector,
-//        int numberOfAttempts,
-//        long delayInMs
-//    ) {
-//        try {
-//            Thread.sleep(delayInMs);
-//        } catch (InterruptedException e) {
-//            throw new RuntimeException(e);
-//        }
-//
-//        // Try a certain number of times
-//        final int originalSize = collector.getEmissions().size();
-//        for (int x = 0; x < numberOfAttempts; x++) {
-//            // Call next Tuple
-//            spout.nextTuple();
-//
-//            // If we get an unexpected emission
-//            if (originalSize != collector.getEmissions().size()) {
-//                // Lets log it
-//                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
-//            }
-//            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
-//        }
-//    }
-//
-//    /**
-//     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
-//     * @param spout - The spout instance to call nextTuple() on.
-//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
-//     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
-//     */
-//    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
-//        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
-//
-//        // Create a new list for the emissions we expect to get back
-//        List<SpoutEmission> newEmissions = Lists.newArrayList();
-//
-//        // Determine how many emissions are already in the collector
-//        final int existingEmissionsCount = collector.getEmissions().size();
-//
-//        // Call next tuple N times
-//        for (int x = 0; x < numberOfTuples; x++) {
-//            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
-//            await()
-//                .atMost(5, TimeUnit.SECONDS)
-//                .until(() -> {
-//                    // Ask for next tuple
-//                    spout.nextTuple();
-//
-//                    // Return how many tuples have been emitted so far
-//                    // It should be equal to our loop count + 1
-//                    return collector.getEmissions().size();
-//                }, equalTo(existingEmissionsCount + x + 1));
-//
-//            // Should have some emissions
-//            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
-//
-//            // Add our new emission to our return list
-//            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
-//        }
-//
-//        // Log them for reference.
-//        logger.info("Found new emissions: {}", newEmissions);
-//        return newEmissions;
-//    }
-//
-//    /**
-//     * Given a list of produced kafka messages, and a list of tuples that got emitted,
-//     * make sure that the tuples match up with what we expected to get sent out.
-//     *  @param producedRecords the original records produced into kafka.
-//     * @param spoutEmissions the tuples that got emitted out from the spout
-//     * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
-//     * @param expectedConsumerId consumer id we expected
-//     */
-//    private void validateTuplesFromSourceMessages(
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
-//        final List<SpoutEmission> spoutEmissions,
-//        final String expectedStreamId,
-//        final String expectedConsumerId
-//    ) {
-//        // Sanity check, make sure we have the same number of each.
-//        assertEquals(
-//            "Should have same number of tuples as original messages, Produced Count: " + producedRecords.size()
-//                + " Emissions Count: " + spoutEmissions.size(),
-//            producedRecords.size(),
-//            spoutEmissions.size()
-//        );
-//
-//        // Iterator over what got emitted
-//        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
-//
-//        // Loop over what we produced into kafka
-//        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
-//            // Now find its corresponding tuple from our iterator
-//            final SpoutEmission spoutEmission = emissionIterator.next();
-//
-//            // validate that they match
-//            validateEmission(producedRecord, spoutEmission, expectedConsumerId, expectedStreamId);
-//        }
-//    }
-//
-//    /**
-//     * Waits for virtual spouts to close out.
-//     * @param spout - The spout instance
-//     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
-//     */
-//    private void waitForVirtualSpouts(DynamicSpout spout, int howManyVirtualSpoutsWeWantLeft) {
-//        await()
-//            .atMost(5, TimeUnit.SECONDS)
-//            .until(() -> spout.getSpoutCoordinator().getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
-//        assertEquals(
-//            "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
-//            howManyVirtualSpoutsWeWantLeft,
-//            spout.getSpoutCoordinator().getTotalSpouts()
-//        );
-//    }
+    /**
+     * Our most simple end-2-end test.
+     * This test stands up our spout and ask it to consume from our kafka namespace.
+     * We publish some data into kafka, and validate that when we call nextTuple() on
+     * our spout that we get out our messages that were published into kafka.
+     *
+     * This does not make use of any side lining logic, just simple consuming from the
+     * 'fire hose' consumer.
+     *
+     * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
+     * output stream name (default), as well as an explicitly configured stream name.
+     */
+    @Test
+    @UseDataProvider("provideStreamIds")
+    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
+        // Define how many tuples we should push into the namespace, and then consume back out.
+        final int emitTupleCount = 10;
+
+        // Define our ConsumerId prefix
+        final String consumerIdPrefix = "KafkaConsumerSpout";
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
+
+        // If we have a stream Id we should be configured with
+        if (configuredStreamId != null) {
+            // Drop it into our configuration.
+            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
+        }
+
+        // Some mock storm topology stuff to get going
+        final TopologyContext topologyContext = new MockTopologyContext();
+        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create spout and call open
+        final DynamicSpout spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Add a VirtualSpout.
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("Main");
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for VirtualSpout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Call next tuple, topic is empty, so nothing should get emitted.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
+
+        // Lets produce some data into the topic
+        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+
+        // Now consume tuples generated from the messages we published into kafka.
+        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+
+        // Validate the tuples that got emitted are what we expect based on what we published into kafka
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
+
+        // Call next tuple a few more times to make sure nothing unexpected shows up.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
+
+        // Cleanup.
+        spout.close();
+    }
+
+    /**
+     * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
+     * retry manager.
+     *
+     * This test stands up our spout and ask it to consume from our kafka namespace.
+     * We publish some data into kafka, and validate that when we call nextTuple() on
+     * our spout that we get out our messages that were published into kafka.
+     *
+     * We then fail some tuples and validate that they get replayed.
+     * We ack some tuples and then validate that they do NOT get replayed.
+     *
+     * This does not make use of any side lining logic, just simple consuming from the
+     * 'fire hose' namespace.
+     */
+    @Test
+    public void doBasicFailTest() throws InterruptedException {
+        // Define how many tuples we should push into the namespace, and then consume back out.
+        final int emitTupleCount = 10;
+
+        // Define our ConsumerId prefix
+        final String consumerIdPrefix = "KafkaConsumerSpout";
+
+        // Define our output stream id
+        final String expectedStreamId = "default";
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+
+        // Configure to use our FailedTuplesFirstRetryManager retry manager.
+        config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
+
+        // Some mock stuff to get going
+        final TopologyContext topologyContext = new MockTopologyContext();
+        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create spout and call open
+        final DynamicSpout spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // validate our streamId
+        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+
+        // Add a VirtualSpout.
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("Main");
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Call next tuple, namespace is empty, so should get nothing.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+
+        // Lets produce some data into the namespace
+        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+
+        // Now loop and get our tuples
+        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+
+        // Now lets validate that what we got out of the spout is what we actually expected.
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
+
+        // Call next tuple a few more times to make sure nothing unexpected shows up.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+
+        // Now lets fail our tuples.
+        failTuples(spout, spoutEmissions);
+
+        // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
+        // And our retry manager should replay them first chance it gets.
+        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, virtualSpoutIdentifier);
+
+        // Now lets ack 2 different offsets, entries 0 and 3.
+        // This means they should never get replayed.
+        List<SpoutEmission> ackedEmissions = Lists.newArrayList();
+        ackedEmissions.add(spoutEmissions.get(0));
+        ackedEmissions.add(spoutEmissions.get(3));
+        ackTuples(spout, ackedEmissions);
+
+        // And lets remove their related KafkaRecords
+        // Remember to remove in reverse order, because ArrayLists have no gaps in indexes :p
+        producedRecords.remove(3);
+        producedRecords.remove(0);
+
+        // And lets fail the others
+        List<SpoutEmission> failEmissions = Lists.newArrayList(spoutEmissions);
+        failEmissions.removeAll(ackedEmissions);
+        failTuples(spout, failEmissions);
+
+        // This is how many we failed.
+        final int failedTuples = failEmissions.size();
+
+        // If we call nextTuple, we should get back our failed emissions
+        final List<SpoutEmission> replayedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, failedTuples);
+
+        // Validate we don't get anything else
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Validate the replayed tuples were our failed ones
+        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, virtualSpoutIdentifier);
+
+        // Now lets ack these
+        ackTuples(spout, replayedEmissions);
+
+        // And validate nextTuple gives us nothing new
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+
+        // Cleanup.
+        spout.close();
+    }
+
+    /**
+     * This test stands up a spout instance and begins consuming from a namespace.
+     * Halfway thru consuming all the messages published in that namespace we will shutdown
+     * the spout gracefully.
+     *
+     * We'll create a new instance of the spout and fire it up, then validate that it resumes
+     * consuming from where it left off.
+     *
+     * Assumptions made in this test:
+     *   - single partition namespace
+     *   - using ZK persistence manager to maintain state between spout instances/restarts.
+     */
+    @Test
+    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException {
+        // Produce 10 messages into kafka (offsets 0->9)
+        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+
+        // Create spout
+        // Define our output stream id
+        final String expectedStreamId = "default";
+        final String consumerIdPrefix = "TestKafkaConsumerSpout";
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+
+        // Use zookeeper persistence manager
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+
+        // Some mock stuff to get going
+        TopologyContext topologyContext = new MockTopologyContext();
+        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create spout and call open
+        DynamicSpout spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // validate our streamId
+        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+
+        // Add a VirtualSpout.
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("Main");
+        VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+        final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
+
+        // Validate its the messages we expected
+        validateEmission(producedRecords.get(0), spoutEmissions.get(0), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(1), spoutEmissions.get(1), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(2), spoutEmissions.get(2), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(3), spoutEmissions.get(3), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(4), spoutEmissions.get(4), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(5), spoutEmissions.get(5), virtualSpoutIdentifier, expectedStreamId);
+
+        // We will ack offsets in the following order: 2,0,1,3,5
+        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+
+        // Stop the spout.
+        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+        spout.close();
+
+        // Create fresh new spoutOutputCollector & topology context
+        topologyContext = new MockTopologyContext();
+        spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create fresh new instance of spout & call open all with the same config
+        spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Create and add virtual spout
+        virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Call next tuple to get remaining tuples out.
+        // It should give us offsets [4,5,6,7,8,9]
+        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
+            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
+        );
+
+        // Validate no further tuples
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Validate its the tuples we expect [4,5,6,7,8,9]
+        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), virtualSpoutIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), virtualSpoutIdentifier, expectedStreamId);
+
+        // Ack all tuples.
+        ackTuples(spout, spoutEmissionsAfterResume);
+
+        // Stop the spout.
+        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+        spout.close();
+
+        // Create fresh new spoutOutputCollector & topology context
+        topologyContext = new MockTopologyContext();
+        spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create fresh new instance of spout & call open all with the same config
+        spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Create new VirtualSpout instance and add it.
+        virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Validate no further tuples, as we acked all the things.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+
+        // And done.
+        spout.close();
+    }
+
+    /**
+     * This is an integration test of multiple Kafka Consumers.
+     * We stand up a topic with 4 partitions.
+     * We then have a consumer size of 2.
+     * We run the test once using consumerIndex 0
+     *   - Verify we only consume from partitions 0 and 1
+     * We run the test once using consumerIndex 1
+     *   - Verify we only consume from partitions 2 and 3
+     * @param taskIndex What taskIndex to run the test with.
+     */
+    @Test
+    @UseDataProvider("providerOfTaskIds")
+    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
+        final int numberOfMsgsPerPartition = 10;
+
+        // Create a namespace with 4 partitions
+        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
+        getKafkaTestServer().createTopic(topicName, 4);
+
+        // Define some topicPartitions
+        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+
+        // produce 10 msgs into even partitions, 11 into odd partitions
+        produceRecords(numberOfMsgsPerPartition, 0);
+        produceRecords(numberOfMsgsPerPartition + 1, 1);
+        produceRecords(numberOfMsgsPerPartition, 2);
+        produceRecords(numberOfMsgsPerPartition + 1, 3);
+
+        // Some initial setup
+        final List<ConsumerPartition> expectedPartitions;
+        if (taskIndex == 0) {
+            // If we're consumerIndex 0, we expect partitionIds 0 or 1
+            expectedPartitions = Lists.newArrayList(partition0 , partition1);
+        } else if (taskIndex == 1) {
+            // If we're consumerIndex 0, we expect partitionIds 2 or 3
+            expectedPartitions = Lists.newArrayList(partition2 , partition3);
+        } else {
+            throw new RuntimeException("Invalid input to test");
+        }
+
+        // Create spout
+        // Define our output stream id
+        final String expectedStreamId = "default";
+        final String consumerIdPrefix = "TestKafkaConsumerSpout";
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+
+        // Use zookeeper persistence manager
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+
+        // Create topology context, set our task index
+        MockTopologyContext topologyContext = new MockTopologyContext();
+        topologyContext.taskId = taskIndex;
+        topologyContext.taskIndex = taskIndex;
+
+        // Say that we have 2 tasks, ids 0 and 1
+        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0, 1));
+
+        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout and call open().
+        DynamicSpout spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // validate our streamId
+        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+
+        // Create and add virtualSpout
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("Main");
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for our virtual spout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
+        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
+
+        // Validate they all came from the correct partitions
+        for (SpoutEmission spoutEmission : spoutEmissions) {
+            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+
+            // Validate it came from the right place
+            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+        }
+
+        // Validate we don't have any other emissions
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+
+        // Lets ack our tuples
+        ackTuples(spout, spoutEmissions);
+
+        // Close
+        spout.close();
+    }
+
+    /**
+     * This is an integration test of multiple Kafka Consumers.
+     * We stand up a topic with 4 partitions.
+     * We then have a consumer size of 2.
+     * We run the test once using consumerIndex 0
+     *   - Verify we only consume from partitions 0 and 1
+     * We run the test once using consumerIndex 1
+     *   - Verify we only consume from partitions 2 and 3
+     * @param taskIndex What taskIndex to run the test with.
+     */
+    @Test
+    @UseDataProvider("providerOfTaskIds")
+    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
+        final int numberOfMsgsPerPartition = 10;
+
+        // Create a namespace with 4 partitions
+        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
+        getKafkaTestServer().createTopic(topicName, 5);
+
+        // Define some topicPartitions
+        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
+
+        // produce 10 msgs into even partitions, 11 into odd partitions
+        produceRecords(numberOfMsgsPerPartition, 0);
+        produceRecords(numberOfMsgsPerPartition + 1, 1);
+        produceRecords(numberOfMsgsPerPartition, 2);
+        produceRecords(numberOfMsgsPerPartition + 1, 3);
+        produceRecords(numberOfMsgsPerPartition, 4);
+
+        // Some initial setup
+        final List<ConsumerPartition> expectedPartitions;
+        final int expectedNumberOfTuplesToConsume;
+        if (taskIndex == 0) {
+            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
+            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
+
+            // We expect to get out 31 tuples
+            expectedNumberOfTuplesToConsume = 31;
+        } else if (taskIndex == 1) {
+            // If we're consumerIndex 0, we expect partitionIds 3 or 4
+            expectedPartitions = Lists.newArrayList(partition3 , partition4);
+
+            // We expect to get out 21 tuples
+            expectedNumberOfTuplesToConsume = 21;
+        } else {
+            throw new RuntimeException("Invalid input to test");
+        }
+
+        // Create spout
+        // Define our output stream id
+        final String expectedStreamId = "default";
+        final String consumerIdPrefix = "TestKafkaConsumerSpout";
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+
+        // Use zookeeper persistence manager
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+
+        // Create topology context, set our task index
+        MockTopologyContext topologyContext = new MockTopologyContext();
+        topologyContext.taskId = taskIndex;
+        topologyContext.taskIndex = taskIndex;
+
+        // Say that we have 2 tasks, ids 0 and 1
+        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
+
+        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout and call open().
+        DynamicSpout spout = new DynamicSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // validate our streamId
+        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+
+        // Create and add virtualSpout
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = new DefaultVirtualSpoutIdentifier("Main");
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            virtualSpoutIdentifier,
+            config,
+            topologyContext,
+            new FactoryManager(config),
+            new LogRecorder(),
+            null,
+            null
+        );
+        spout.addVirtualSpout(virtualSpout);
+
+        // Wait for our virtual spout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
+        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
+
+        // Validate they all came from the correct partitions
+        for (SpoutEmission spoutEmission : spoutEmissions) {
+            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+
+            // Validate it came from the right place
+            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+        }
+
+        // Validate we don't have any other emissions
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+
+        // Lets ack our tuples
+        ackTuples(spout, spoutEmissions);
+
+        // Close
+        spout.close();
+    }
+
+    /**
+     * Provides task ids 0 and 1.
+     */
+    @DataProvider
+    public static Object[][] providerOfTaskIds() {
+        return new Object[][]{
+            {0},
+            {1}
+        };
+    }
+
+    // Helper methods
+
+    /**
+     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
+     * got emitted by the spout, and make sure everything matches up to what we expected.
+     *
+     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
+     * @param spoutEmission - The SpoutEmissions we got out of the spout
+     * @param expectedVirtualSpoutId - What virtualSpoutId these emissions should be associated with.
+     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
+     */
+    private void validateEmission(
+        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
+        final SpoutEmission spoutEmission,
+        final VirtualSpoutIdentifier expectedVirtualSpoutId,
+        final String expectedOutputStreamId
+    ) {
+        // Now find its corresponding tuple
+        assertNotNull("Not null sanity check", spoutEmission);
+        assertNotNull("Not null sanity check", sourceProducerRecord);
+
+        // Validate Message Id
+        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
+        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
+
+        // Grab the messageId and validate it
+        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
+        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
+        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
+        assertEquals("Expected Source Consumer Id", expectedVirtualSpoutId, messageId.getSrcVirtualSpoutId());
+
+        // Validate Tuple Contents
+        List<Object> tupleValues = spoutEmission.getTuple();
+        assertNotNull("Tuple Values should not be null", tupleValues);
+        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
+
+        // For now the values in the tuple should be 'key' and 'value', this may change.
+        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
+        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
+        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
+
+        // Validate Emit Parameters
+        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
+    }
+
+    /**
+     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
+     * to actually ack them before returning.
+     *
+     * @param spout - the Spout instance to ack tuples on.
+     * @param spoutEmissions - The SpoutEmissions we want to ack.
+     */
+    private void ackTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+        if (spoutEmissions.isEmpty()) {
+            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
+        }
+
+        // Ack each one.
+        for (SpoutEmission emission: spoutEmissions) {
+            spout.ack(emission.getMessageId());
+        }
+
+        // Grab reference to message bus.
+        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+
+        // Acking tuples is an async process, so we need to make sure they get picked up
+        // and processed before continuing.
+        await()
+            .atMost(6500, TimeUnit.MILLISECONDS)
+            .until(() -> {
+                // Wait for our tuples to get popped off the acked queue.
+                return messageBus.ackSize() == 0;
+            }, equalTo(true));
+    }
+
+    /**
+     * Utility method to fail tuples on a spout.  This will wait for the underlying VirtualSpout instance
+     * to actually fail them before returning.
+     *
+     * @param spout - the Spout instance to ack tuples on.
+     * @param spoutEmissions - The SpoutEmissions we want to ack.
+     */
+    private void failTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+        if (spoutEmissions.isEmpty()) {
+            throw new RuntimeException("You cannot fail an empty list!  You probably have a bug in your test.");
+        }
+
+        // Fail each one.
+        for (SpoutEmission emission: spoutEmissions) {
+            spout.fail(emission.getMessageId());
+        }
+
+        // Grab reference to message bus.
+        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+
+        // Failing tuples is an async process, so we need to make sure they get picked up
+        // and processed before continuing.
+        await()
+            .atMost(6500, TimeUnit.MILLISECONDS)
+            .until(() -> {
+                // Wait for our tuples to get popped off the fail queue.
+                return messageBus.failSize() == 0;
+            }, equalTo(true));
+    }
+
+    /**
+     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
+     * @param spout - The spout instance to call nextTuple() on.
+     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+     * @param numberOfAttempts - How many times to call nextTuple()
+     */
+    private void validateNextTupleEmitsNothing(
+        DynamicSpout spout,
+        MockSpoutOutputCollector collector,
+        int numberOfAttempts,
+        long delayInMs
+    ) {
+        try {
+            Thread.sleep(delayInMs);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Try a certain number of times
+        final int originalSize = collector.getEmissions().size();
+        for (int x = 0; x < numberOfAttempts; x++) {
+            // Call next Tuple
+            spout.nextTuple();
+
+            // If we get an unexpected emission
+            if (originalSize != collector.getEmissions().size()) {
+                // Lets log it
+                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
+            }
+            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
+        }
+    }
+
+    /**
+     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
+     * @param spout - The spout instance to call nextTuple() on.
+     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
+     */
+    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
+        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
+
+        // Create a new list for the emissions we expect to get back
+        List<SpoutEmission> newEmissions = Lists.newArrayList();
+
+        // Determine how many emissions are already in the collector
+        final int existingEmissionsCount = collector.getEmissions().size();
+
+        // Call next tuple N times
+        for (int x = 0; x < numberOfTuples; x++) {
+            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
+            await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> {
+                    // Ask for next tuple
+                    spout.nextTuple();
+
+                    // Return how many tuples have been emitted so far
+                    // It should be equal to our loop count + 1
+                    return collector.getEmissions().size();
+                }, equalTo(existingEmissionsCount + x + 1));
+
+            // Should have some emissions
+            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
+
+            // Add our new emission to our return list
+            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
+        }
+
+        // Log them for reference.
+        logger.info("Found new emissions: {}", newEmissions);
+        return newEmissions;
+    }
+
+    /**
+     * Given a list of produced kafka messages, and a list of tuples that got emitted,
+     * make sure that the tuples match up with what we expected to get sent out.
+     *  @param producedRecords the original records produced into kafka.
+     * @param spoutEmissions the tuples that got emitted out from the spout
+     * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
+     * @param expectedVirtualSpoutId virtual spout id we expected
+     */
+    private void validateTuplesFromSourceMessages(
+        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
+        final List<SpoutEmission> spoutEmissions,
+        final String expectedStreamId,
+        final VirtualSpoutIdentifier expectedVirtualSpoutId
+    ) {
+        // Sanity check, make sure we have the same number of each.
+        assertEquals(
+            "Should have same number of tuples as original messages, Produced Count: "
+            + producedRecords.size() + " Emissions Count: " + spoutEmissions.size(),
+            producedRecords.size(),
+            spoutEmissions.size()
+        );
+
+        // Iterator over what got emitted
+        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
+
+        // Loop over what we produced into kafka
+        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
+            // Now find its corresponding tuple from our iterator
+            final SpoutEmission spoutEmission = emissionIterator.next();
+
+            // validate that they match
+            validateEmission(producedRecord, spoutEmission, expectedVirtualSpoutId, expectedStreamId);
+        }
+    }
+
+    /**
+     * Waits for virtual spouts to close out.
+     * @param spout - The spout instance
+     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
+     */
+    private void waitForVirtualSpouts(DynamicSpout spout, int howManyVirtualSpoutsWeWantLeft) {
+        await()
+            .atMost(5, TimeUnit.SECONDS)
+            .until(() -> spout.getSpoutCoordinator().getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
+        assertEquals(
+            "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
+            howManyVirtualSpoutsWeWantLeft,
+            spout.getSpoutCoordinator().getTotalSpouts()
+        );
+    }
 
     /**
      * helper method to produce records into kafka.
@@ -1311,9 +927,9 @@ public class KafkaConsumerSpoutTest {
      */
     private Map<String, Object> getDefaultConfig(final String consumerIdPrefix, final String configuredStreamId) {
         // Generate a unique zkRootNode for each test
-        final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
+        final String uniqueZkRootNode = "/kafkaconsumer-spout-test/testRun" + System.currentTimeMillis();
 
-        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
+        final Map<String, Object> config = SpoutConfig.setDefaults(Maps.newHashMap());
 
         // Kafka Consumer config items
         config.put(SpoutConfig.CONSUMER_CLASS, Consumer.class.getName());
@@ -1330,15 +946,6 @@ public class KafkaConsumerSpoutTest {
         // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
         config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
 
-        // TODO: Separate the dependencies on this from this test!!!
-        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
-        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
-        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
-
         // Configure SpoutCoordinator thread to run every 1 second
         config.put(SpoutConfig.MONITOR_THREAD_INTERVAL_MS, 1000L);
 
@@ -1347,12 +954,6 @@ public class KafkaConsumerSpoutTest {
 
         // For now use the Log Recorder
         config.put(SpoutConfig.METRICS_RECORDER_CLASS, LogRecorder.class.getName());
-
-        config.put(SpoutConfig.SPOUT_HANDLER_CLASS, SidelineSpoutHandler.class.getName());
-
-        config.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
-
-        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
 
         // If we have a stream Id we should be configured with
         if (configuredStreamId != null) {

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
@@ -44,7 +44,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
- * Mock consumer instance.
+ * Mock consumer implementation, used within tests.
  */
 public class MockConsumer implements Consumer {
     private static final Map<VirtualSpoutIdentifier,BlockingQueue<Record>> recordHolder = Maps.newConcurrentMap();
@@ -131,7 +131,7 @@ public class MockConsumer implements Consumer {
      * @param partitions list of partition ids.
      * @return consumer state instance for the provided partition ids.
      */
-    public static ConsumerState buildConsumerState(List<Integer> partitions) {
+    static ConsumerState buildConsumerState(List<Integer> partitions) {
         ConsumerState.ConsumerStateBuilder builder = ConsumerState.builder();
 
         for (Integer partition : partitions) {
@@ -171,6 +171,11 @@ public class MockConsumer implements Consumer {
         }
     }
 
+    /**
+     * Return all Namespace/Offsets that have been committed for a given VirtualSpoutIdentifier.
+     * @param virtualSpoutIdentifier The VirtualSpout to get committed offsets for.
+     * @return List of Committed Offsets.
+     */
     public static List<CommittedState> getCommitted(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
         synchronized (MockConsumer.class) {
             if (!committedStateHolder.containsKey(virtualSpoutIdentifier)) {
@@ -180,6 +185,9 @@ public class MockConsumer implements Consumer {
         }
     }
 
+    /**
+     * Value object containing information about Committed Offsets.
+     */
     public static class CommittedState {
         private final String namespace;
         private final int partition;

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -34,7 +34,6 @@ import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.consumer.Consumer;
 import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
 import com.salesforce.storm.spout.dynamic.DelegateSpout;
-import com.salesforce.storm.spout.dynamic.consumer.MockConsumer;
 
 import java.util.Queue;
 import java.util.Set;

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockSpoutHandler.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockSpoutHandler.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.mocks;
+
+import com.salesforce.storm.spout.dynamic.DynamicSpout;
+import com.salesforce.storm.spout.dynamic.handler.SpoutHandler;
+import org.apache.storm.task.TopologyContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A stand-in implementation of SpoutHandler used in tests.
+ */
+public class MockSpoutHandler implements SpoutHandler {
+    private Map<String, Object> spoutConfig = null;
+
+    private boolean hasCalledOpen = false;
+    private boolean hasCalledClosed = false;
+
+    private List<OpenedSpoutParams> openedSpouts = new ArrayList<>();
+    private List<DynamicSpout> activatedSpouts = new ArrayList<>();
+    private List<DynamicSpout> closedSpouts = new ArrayList<>();
+    private List<DynamicSpout> deactivatedSpouts = new ArrayList<>();
+
+    /**
+     * Open the handler.
+     * @param spoutConfig Spout configuration.
+     */
+    public void open(Map<String, Object> spoutConfig) {
+        hasCalledOpen = true;
+        this.spoutConfig = spoutConfig;
+    }
+
+    /**
+     * Close the handler.
+     */
+    public void close() {
+        hasCalledClosed = true;
+    }
+
+    /**
+     * Called when the DynamicSpout is opened.
+     * @param spout DynamicSpout instance.
+     * @param topologyConfig Topology configuration.
+     * @param topologyContext Topology context.
+     */
+    public void onSpoutOpen(DynamicSpout spout, Map topologyConfig, TopologyContext topologyContext) {
+        openedSpouts.add(
+            new OpenedSpoutParams(spout, topologyConfig, topologyContext)
+        );
+    }
+
+    /**
+     * Called when the DynamicSpout is activated.
+     * @param spout DynamicSpout instance.
+     */
+    public void onSpoutActivate(final DynamicSpout spout) {
+        activatedSpouts.add(spout);
+    }
+
+    /**
+     * Called when the DynamicSpout is deactivated.
+     * @param spout DynamicSpout instance.
+     */
+    public void onSpoutDeactivate(final DynamicSpout spout) {
+        deactivatedSpouts.add(spout);
+    }
+
+    /**
+     * Called when the DynamicSpout is closed.
+     * @param spout DynamicSpout instance.
+     */
+    public void onSpoutClose(final DynamicSpout spout) {
+        closedSpouts.add(spout);
+    }
+
+    public Map<String, Object> getSpoutConfig() {
+        return spoutConfig;
+    }
+
+    public boolean isHasCalledOpen() {
+        return hasCalledOpen;
+    }
+
+    public boolean isHasCalledClosed() {
+        return hasCalledClosed;
+    }
+
+    public List<OpenedSpoutParams> getOpenedSpouts() {
+        return openedSpouts;
+    }
+
+    public List<DynamicSpout> getActivatedSpouts() {
+        return activatedSpouts;
+    }
+
+    public List<DynamicSpout> getClosedSpouts() {
+        return closedSpouts;
+    }
+
+    public List<DynamicSpout> getDeactivatedSpouts() {
+        return deactivatedSpouts;
+    }
+
+    /**
+     * For collecting parameters passed to open() method.
+     */
+    public static class OpenedSpoutParams {
+        private final DynamicSpout spout;
+        private final Map config;
+        private final TopologyContext topologyContext;
+
+        private OpenedSpoutParams(final DynamicSpout spout, final Map config, final TopologyContext topologyContext) {
+            this.spout = spout;
+            this.config = config;
+            this.topologyContext = topologyContext;
+        }
+
+        public DynamicSpout getSpout() {
+            return spout;
+        }
+
+        public Map getConfig() {
+            return config;
+        }
+
+        public TopologyContext getTopologyContext() {
+            return topologyContext;
+        }
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -523,7 +523,7 @@ public class SidelineSpoutTest {
      * @param spout - the Spout instance to ack tuples on.
      * @param spoutEmissions - The SpoutEmissions we want to ack.
      */
-    private void ackTuples(final DynamicSpout spout, final List<SpoutEmission> spoutEmissions) {
+    private void ackTuples(final SidelineSpout spout, final List<SpoutEmission> spoutEmissions) {
         if (spoutEmissions.isEmpty()) {
             throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
         }
@@ -536,7 +536,7 @@ public class SidelineSpoutTest {
         // Make method accessible.
         try {
             // TODO find better way to do this w/o reflections.
-            final Field field = spout.getClass().getDeclaredField("messageBus");
+            final Field field = DynamicSpout.class.getDeclaredField("messageBus");
             field.setAccessible(true);
 
             // Grab reference to message bus.
@@ -668,16 +668,16 @@ public class SidelineSpoutTest {
      * @param spout - The spout instance
      * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
      */
-    private void waitForVirtualSpouts(final DynamicSpout spout, final int howManyVirtualSpoutsWeWantLeft) {
+    private void waitForVirtualSpouts(final SidelineSpout spout, final int howManyVirtualSpoutsWeWantLeft) {
         try {
             // TODO find better way to do this avoiding reflections
-            final Field field = spout.getClass().getDeclaredField("spoutCoordinator");
+            final Field field = DynamicSpout.class.getDeclaredField("spoutCoordinator");
             field.setAccessible(true);
             final SpoutCoordinator spoutCoordinator = (SpoutCoordinator) field.get(spout);
 
             await()
                 .atMost(5, TimeUnit.SECONDS)
-                .until(() -> spoutCoordinator.getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
+                .until(spoutCoordinator::getTotalSpouts, equalTo(howManyVirtualSpoutsWeWantLeft));
             assertEquals(
                 "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
                 howManyVirtualSpoutsWeWantLeft,

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -83,7 +83,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test coverage for SidelineSpout specific functionality.
+ * Provides End-To-End integration test coverage for SidelineSpout specific functionality.
  * This test does not attempt to validate all pieces of DynamicSpout, as that is covered by DynamicSpoutTest.
  */
 @RunWith(DataProviderRunner.class)

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -523,7 +523,7 @@ public class SidelineSpoutTest {
      * @param spout - the Spout instance to ack tuples on.
      * @param spoutEmissions - The SpoutEmissions we want to ack.
      */
-    private void ackTuples(final SidelineSpout spout, final List<SpoutEmission> spoutEmissions) {
+    private void ackTuples(final DynamicSpout spout, final List<SpoutEmission> spoutEmissions) {
         if (spoutEmissions.isEmpty()) {
             throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
         }
@@ -668,7 +668,7 @@ public class SidelineSpoutTest {
      * @param spout - The spout instance
      * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
      */
-    private void waitForVirtualSpouts(final SidelineSpout spout, final int howManyVirtualSpoutsWeWantLeft) {
+    private void waitForVirtualSpouts(final DynamicSpout spout, final int howManyVirtualSpoutsWeWantLeft) {
         try {
             // TODO find better way to do this avoiding reflections
             final Field field = spout.getClass().getDeclaredField("spoutCoordinator");

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -1,3 +1,28 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package com.salesforce.storm.spout.sideline;
 
 import com.google.common.base.Charsets;
@@ -7,12 +32,13 @@ import com.salesforce.kafka.test.KafkaTestServer;
 import com.salesforce.kafka.test.KafkaTestUtils;
 import com.salesforce.kafka.test.ProducedKafkaRecord;
 import com.salesforce.kafka.test.junit.SharedKafkaTestResource;
-import com.salesforce.storm.spout.dynamic.ConsumerPartition;
+import com.salesforce.storm.spout.dynamic.DefaultVirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.DynamicSpout;
-import com.salesforce.storm.spout.dynamic.DynamicSpoutTest;
 import com.salesforce.storm.spout.dynamic.MessageBus;
 import com.salesforce.storm.spout.dynamic.MessageId;
+import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
+import com.salesforce.storm.spout.dynamic.coordinator.SpoutCoordinator;
 import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
 import com.salesforce.storm.spout.dynamic.kafka.Consumer;
 import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
@@ -23,34 +49,27 @@ import com.salesforce.storm.spout.dynamic.mocks.output.MockSpoutOutputCollector;
 import com.salesforce.storm.spout.dynamic.mocks.output.SpoutEmission;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
-import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
 import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
-import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
-import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
 import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.apache.storm.generated.StreamInfo;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsGetter;
-import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
-import org.apache.zookeeper.KeeperException;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Clock;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -64,11 +83,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- *
+ * Test coverage for SidelineSpout specific functionality.
+ * This test does not attempt to validate all pieces of DynamicSpout, as that is covered by DynamicSpoutTest.
  */
+@RunWith(DataProviderRunner.class)
 public class SidelineSpoutTest {
     // For logging within the test.
-    private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(SidelineSpoutTest.class);
 
     /**
      * Create shared kafka test server.
@@ -88,1246 +109,582 @@ public class SidelineSpoutTest {
     @Before
     public void beforeTest() throws InterruptedException {
         // Generate namespace name
-        topicName = DynamicSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
+        topicName = SidelineSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
 
         // Create namespace
         getKafkaTestServer().createTopic(topicName);
     }
 
-//    /**
-//     * Our most simple end-2-end test.
-//     * This test stands up our spout and ask it to consume from our kafka namespace.
-//     * We publish some data into kafka, and validate that when we call nextTuple() on
-//     * our spout that we get out our messages that were published into kafka.
-//     *
-//     * This does not make use of any side lining logic, just simple consuming from the
-//     * 'fire hose' consumer.
-//     *
-//     * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
-//     * output stream name (default), as well as an explicitly configured stream name.
-//     */
-//    @Test
-//    @UseDataProvider("provideStreamIds")
-//    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
-//        // Define how many tuples we should push into the namespace, and then consume back out.
-//        final int emitTupleCount = 10;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
-//
-//        // If we have a stream Id we should be configured with
-//        if (configuredStreamId != null) {
-//            // Drop it into our configuration.
-//            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
-//        }
-//
-//        // Some mock storm topology stuff to get going
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple, namespace is empty, so nothing should get emitted.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
-//
-//        // Lets produce some data into the namespace
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
-//
-//        // Now consume tuples generated from the messages we published into kafka.
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//
-//        // Validate the tuples that got emitted are what we expect based on what we published into kafka
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Call next tuple a few more times to make sure nothing unexpected shows up.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
-//
-//        // Cleanup.
-//        spout.close();
-//    }
-//
-//    /**
-//     * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
-//     * retry manager.
-//     *
-//     * This test stands up our spout and ask it to consume from our kafka namespace.
-//     * We publish some data into kafka, and validate that when we call nextTuple() on
-//     * our spout that we get out our messages that were published into kafka.
-//     *
-//     * We then fail some tuples and validate that they get replayed.
-//     * We ack some tuples and then validate that they do NOT get replayed.
-//     *
-//     * This does not make use of any side lining logic, just simple consuming from the
-//     * 'fire hose' namespace.
-//     */
-//    @Test
-//    public void doBasicFailTest() throws InterruptedException {
-//        // Define how many tuples we should push into the namespace, and then consume back out.
-//        final int emitTupleCount = 10;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "SidelineSpout";
-//
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Configure to use our FailedTuplesFirstRetryManager retry manager.
-//        config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
-//
-//        // Some mock stuff to get going
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple, namespace is empty, so should get nothing.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Lets produce some data into the namespace
-//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
-//
-//        // Now loop and get our tuples
-//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//
-//        // Now lets validate that what we got out of the spout is what we actually expected.
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Call next tuple a few more times to make sure nothing unexpected shows up.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Now lets fail our tuples.
-//        failTuples(spout, spoutEmissions);
-//
-//        // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
-//        // And our retry manager should replay them first chance it gets.
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Now lets ack 2 different offsets, entries 0 and 3.
-//        // This means they should never get replayed.
-//        List<SpoutEmission> ackedEmissions = Lists.newArrayList();
-//        ackedEmissions.add(spoutEmissions.get(0));
-//        ackedEmissions.add(spoutEmissions.get(3));
-//        ackTuples(spout, ackedEmissions);
-//
-//        // And lets remove their related KafkaRecords
-//        // Remember to remove in reverse order, because ArrayLists have no gaps in indexes :p
-//        producedRecords.remove(3);
-//        producedRecords.remove(0);
-//
-//        // And lets fail the others
-//        List<SpoutEmission> failEmissions = Lists.newArrayList(spoutEmissions);
-//        failEmissions.removeAll(ackedEmissions);
-//        failTuples(spout, failEmissions);
-//
-//        // This is how many we failed.
-//        final int failedTuples = failEmissions.size();
-//
-//        // If we call nextTuple, we should get back our failed emissions
-//        final List<SpoutEmission> replayedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, failedTuples);
-//
-//        // Validate we don't get anything else
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate the replayed tuples were our failed ones
-//        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Now lets ack these
-//        ackTuples(spout, replayedEmissions);
-//
-//        // And validate nextTuple gives us nothing new
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
-//
-//        // Cleanup.
-//        spout.close();
-//    }
-//
-//    /**
-//     * Our most basic End 2 End test that includes basic sidelining.
-//     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
-//     * Records 1 and 2 we get out of the spout.
-//     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
-//     * We stop sidelining, this should cause a virtual spout to be started within the spout.
-//     * Calling nextTuple() should get back the records that were previously skipped.
-//     * We produce additional records into the namespace.
-//     * Call nextTuple() and we should get them out.
-//     */
-//    @Test
-//    public void doTestWithSidelining() throws InterruptedException {
-//        // How many records to publish into kafka per go.
-//        final int numberOfRecordsToPublish = 3;
-//
-//        // Define our ConsumerId prefix
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//
-//        // Create our Config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Create some stand-in mocks.
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        final DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Produce records into kafka
-//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-//        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
-//        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
-//        // to be emitted.
-//        // Grab out the emissions so we can validate them.
-//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // Validate the tuples are what we published into kafka
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
-//        assertEquals("Should have a single VirtualSpout instance", 1, spout.getSpoutCoordinator().getTotalSpouts());
-//
-//        // Create a static message filter, this allows us to easily start filtering messages.
-//        // It should filter ALL messages
-//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-//
-//        // Send a new start request with our filter.
-//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-//        StaticTrigger.sendStartRequest(request);
-//
-//        // Produce another 3 records into kafka.
-//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // We basically want the time that would normally pass before we check that there are no new tuples
-//        // Call next tuple, it should NOT receive any tuples because
-//        // all tuples are filtered.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-//
-//        // Send a stop sideline request
-//        StaticTrigger.sendStopRequest(request);
-//
-//        // We need to wait a bit for the sideline spout instance to spin up
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Then ask the spout for tuples, we should get back the tuples that were produced while
-//        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // We should validate these emissions
-//        validateTuplesFromSourceMessages(
-//            producedRecords,
-//            spoutEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":sideline:" + request.id
-//        );
-//
-//        // Call next tuple a few more times to be safe nothing else comes in.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
-//        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
-//        assertEquals("We should have 2 virtual spouts running", 2, spout.getSpoutCoordinator().getTotalSpouts());
-//
-//        // Lets ack our messages.
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
-//        // We need to wait for the monitor thread to run to clean it up.
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Produce some more records, verify they come in the firehose.
-//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
-//
-//        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
-//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
-//
-//        // Loop over what we produced into kafka and validate them
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Close out
-//        spout.close();
-//    }
-//
-//    /**
-//     * This test stands up a spout instance and begins consuming from a namespace.
-//     * Halfway thru consuming all the messages published in that namespace we will shutdown
-//     * the spout gracefully.
-//     *
-//     * We'll create a new instance of the spout and fire it up, then validate that it resumes
-//     * consuming from where it left off.
-//     *
-//     * Assumptions made in this test:
-//     *   - single partition namespace
-//     *   - using ZK persistence manager to maintain state between spout instances/restarts.
-//     */
-//    @Test
-//    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException, KeeperException {
-//        // Produce 10 messages into kafka (offsets 0->9)
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Some mock stuff to get going
-//        TopologyContext topologyContext = new MockTopologyContext();
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout and call open
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
-//        final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
-//
-//        // Validate its the messages we expected
-//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // We will ack offsets in the following order: 2,0,1,3,5
-//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // Create fresh new spoutOutputCollector & topology context
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create fresh new instance of spout & call open all with the same config
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Call next tuple to get remaining tuples out.
-//        // It should give us offsets [4,5,6,7,8,9]
-//        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
-//            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
-//        );
-//
-//        // Validate no further tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Validate its the tuples we expect [4,5,6,7,8,9]
-//        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // Ack all tuples.
-//        ackTuples(spout, spoutEmissionsAfterResume);
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // Create fresh new spoutOutputCollector & topology context
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create fresh new instance of spout & call open all with the same config
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Validate no further tuples, as we acked all the things.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
-//
-//        // And done.
-//        spout.close();
-//    }
-//
-//    /**
-//     * This test stands up a spout instance and tests sidelining.
-//     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
-//     * we stop the spout, create a new instance and restart it.  If things are working correctly
-//     * the sidelined VirtualSpout should resume from where it left off.
-//     */
-//    @Test
-//    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
-//        // Produce 10 messages into kafka (offsets 0->9)
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//        config.put(
-//            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-//            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
-//        );
-//
-//        // Some mock stuff to get going
-//        TopologyContext topologyContext = new MockTopologyContext();
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
-//
-//        // Validate its the messages we expected
-//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
-//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
-//
-//        // We will ack offsets in the following order: 2,0,1,3,5
-//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
-//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
-//
-//        // Create a static message filter, this allows us to easily start filtering messages.
-//        // It should filter ALL messages
-//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
-//
-//        // Send a new start request with our filter.
-//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
-//        StaticTrigger.sendStartRequest(request);
-//
-//        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
-//
-//        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
-//        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
-//
-//        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
-//        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
-//
-//        // We'll validate them
-//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
-//
-//        // Lets not ack any more tuples from the fire hose, that means the last completed
-//        // offset on the fire hose spout should still be 3.
-//
-//        // Stop the spout.
-//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
-//        spout.close();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout again");
-//        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
-//
-//        // Create new Spout instance and start
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Wait 3 seconds, then verify we have a single virtual spouts running
-//        Thread.sleep(3000L);
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
-//        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
-//
-//        // Send a stop sideline request
-//        StaticTrigger.sendStopRequest(request);
-//
-//        // Verify 2 VirtualSpouts are running
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Call nextTuple() 3 times
-//        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-//
-//        // Verify we get offsets [4,5,6] by validating the tuples
-//        validateEmission(
-//            producedRecords.get(4),
-//            sidelinedEmissions.get(0),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//        validateEmission(
-//            producedRecords.get(5),
-//            sidelinedEmissions.get(1),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//        validateEmission(
-//            producedRecords.get(6),
-//            sidelinedEmissions.get(2),
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
-//            expectedStreamId
-//        );
-//
-//        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
-//        ackTuples(spout, sidelinedEmissions);
-//
-//        // Shut down spout.
-//        spout.close();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout again");
-//        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
-//
-//        // Create new spout instance and start
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Verify we have a 2 virtual spouts running
-//        waitForVirtualSpouts(spout, 2);
-//
-//        // Since last committed offset should be 6,
-//        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
-//        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
-//
-//        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
-//        // Gather up the expected records
-//        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
-//        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
-//        sidelineKafkaRecords.addAll(additionalProducedRecords);
-//
-//        // Validate em.
-//        validateTuplesFromSourceMessages(
-//            sidelineKafkaRecords,
-//            sidelinedEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier
-//        );
-//
-//        // call nextTuple() several times, get nothing back
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
-//        ackTuples(spout, sidelinedEmissions);
-//
-//        // Verify 2nd VirtualSpout shuts off
-//        waitForVirtualSpouts(spout, 1);
-//        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
-//
-//        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
-//        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
-//
-//        // Call nextTuple() 5 times,
-//        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
-//
-//        // verify we get the tuples [15,16,17,18,19]
-//        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
-//
-//        // Ack offsets [15,16,18] => Committed offset should be 16
-//        ackTuples(spout, Lists.newArrayList(
-//            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
-//        ));
-//
-//        // Verify no more tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Stop spout
-//        spout.close();
-//
-//        // Create new spout instance and start.
-//        topologyContext = new MockTopologyContext();
-//        spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // A little debug log
-//        logger.info("=== Starting spout for last time");
-//        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
-//
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        spout = new SidelineSpout(config);
-//
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // Verify we have a single 1 virtual spouts running,
-//        // This makes sure that we don't resume a previously completed sideline request.
-//        Thread.sleep(3000);
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call nextTuple() 3 times,
-//        // verify we get offsets [17,18,19]
-//        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
-//
-//        // Validate we got the right offset [17,18,19]
-//        validateTuplesFromSourceMessages(
-//            lastProducedRecords.subList(2,5),
-//            lastSpoutEmissions,
-//            expectedStreamId,
-//            consumerIdPrefix + ":main"
-//        );
-//
-//        // Verify no more tuples
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
-//
-//        // Stop spout.
-//        spout.close();
-//    }
-//
-//    /**
-//     * This is an integration test of multiple SidelineConsumers.
-//     * We stand up a namespace with 4 partitions.
-//     * We then have a consumer size of 2.
-//     * We run the test once using consumerIndex 0
-//     *   - Verify we only consume from partitions 0 and 1
-//     * We run the test once using consumerIndex 1
-//     *   - Verify we only consume from partitions 2 and 3
-//     * @param taskIndex What taskIndex to run the test with.
-//     */
-//    @Test
-//    @UseDataProvider("providerOfTaskIds")
-//    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
-//        final int numberOfMsgsPerPartition = 10;
-//
-//        // Create a namespace with 4 partitions
-//        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
-//        getKafkaTestServer().createTopic(topicName, 4);
-//
-//        // Define some topicPartitions
-//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-//
-//        // produce 10 msgs into even partitions, 11 into odd partitions
-//        produceRecords(numberOfMsgsPerPartition, 0);
-//        produceRecords(numberOfMsgsPerPartition + 1, 1);
-//        produceRecords(numberOfMsgsPerPartition, 2);
-//        produceRecords(numberOfMsgsPerPartition + 1, 3);
-//
-//        // Some initial setup
-//        final List<ConsumerPartition> expectedPartitions;
-//        if (taskIndex == 0) {
-//            // If we're consumerIndex 0, we expect partitionIds 0 or 1
-//            expectedPartitions = Lists.newArrayList(partition0 , partition1);
-//        } else if (taskIndex == 1) {
-//            // If we're consumerIndex 0, we expect partitionIds 2 or 3
-//            expectedPartitions = Lists.newArrayList(partition2 , partition3);
-//        } else {
-//            throw new RuntimeException("Invalid input to test");
-//        }
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Create topology context, set our task index
-//        MockTopologyContext topologyContext = new MockTopologyContext();
-//        topologyContext.taskId = taskIndex;
-//        topologyContext.taskIndex = taskIndex;
-//
-//        // Say that we have 2 tasks, ids 0 and 1
-//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-//
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Wait for our virtual spout to start
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
-//
-//        // Validate they all came from the correct partitions
-//        for (SpoutEmission spoutEmission : spoutEmissions) {
-//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
-//
-//            // Validate it came from the right place
-//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
-//        }
-//
-//        // Validate we don't have any other emissions
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
-//
-//        // Lets ack our tuples
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Close
-//        spout.close();
-//    }
-//
-//    /**
-//     * This is an integration test of multiple SidelineConsumers.
-//     * We stand up a namespace with 4 partitions.
-//     * We then have a consumer size of 2.
-//     * We run the test once using consumerIndex 0
-//     *   - Verify we only consume from partitions 0 and 1
-//     * We run the test once using consumerIndex 1
-//     *   - Verify we only consume from partitions 2 and 3
-//     * @param taskIndex What taskIndex to run the test with.
-//     */
-//    @Test
-//    @UseDataProvider("providerOfTaskIds")
-//    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
-//        final int numberOfMsgsPerPartition = 10;
-//
-//        // Create a namespace with 4 partitions
-//        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
-//        getKafkaTestServer().createTopic(topicName, 5);
-//
-//        // Define some topicPartitions
-//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
-//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
-//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
-//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
-//        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
-//
-//        // produce 10 msgs into even partitions, 11 into odd partitions
-//        produceRecords(numberOfMsgsPerPartition, 0);
-//        produceRecords(numberOfMsgsPerPartition + 1, 1);
-//        produceRecords(numberOfMsgsPerPartition, 2);
-//        produceRecords(numberOfMsgsPerPartition + 1, 3);
-//        produceRecords(numberOfMsgsPerPartition, 4);
-//
-//        // Some initial setup
-//        final List<ConsumerPartition> expectedPartitions;
-//        final int expectedNumberOfTuplesToConsume;
-//        if (taskIndex == 0) {
-//            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
-//            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
-//
-//            // We expect to get out 31 tuples
-//            expectedNumberOfTuplesToConsume = 31;
-//        } else if (taskIndex == 1) {
-//            // If we're consumerIndex 0, we expect partitionIds 3 or 4
-//            expectedPartitions = Lists.newArrayList(partition3 , partition4);
-//
-//            // We expect to get out 21 tuples
-//            expectedNumberOfTuplesToConsume = 21;
-//        } else {
-//            throw new RuntimeException("Invalid input to test");
-//        }
-//
-//        // Create spout
-//        // Define our output stream id
-//        final String expectedStreamId = "default";
-//        final String consumerIdPrefix = "TestSidelineSpout";
-//
-//        // Create our config
-//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
-//
-//        // Use zookeeper persistence manager
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
-//
-//        // Create topology context, set our task index
-//        MockTopologyContext topologyContext = new MockTopologyContext();
-//        topologyContext.taskId = taskIndex;
-//        topologyContext.taskIndex = taskIndex;
-//
-//        // Say that we have 2 tasks, ids 0 and 1
-//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
-//
-//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create our spout, add references to our static trigger, and call open().
-//        DynamicSpout spout = new SidelineSpout(config);
-//        spout.open(config, topologyContext, spoutOutputCollector);
-//
-//        // validate our streamId
-//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-//
-//        // Wait for our virtual spout to start
-//        waitForVirtualSpouts(spout, 1);
-//
-//        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
-//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
-//
-//        // Validate they all came from the correct partitions
-//        for (SpoutEmission spoutEmission : spoutEmissions) {
-//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
-//
-//            // Validate it came from the right place
-//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
-//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
-//        }
-//
-//        // Validate we don't have any other emissions
-//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
-//
-//        // Lets ack our tuples
-//        ackTuples(spout, spoutEmissions);
-//
-//        // Close
-//        spout.close();
-//    }
-//
-//    /**
-//     * Provides task ids 0 and 1.
-//     */
-//    @DataProvider
-//    public static Object[][] providerOfTaskIds() {
-//        return new Object[][]{
-//            {0},
-//            {1}
-//        };
-//    }
-//
-//    /**
-//     * Tests that pending errors get reported via OutputCollector.
-//     */
-//    @Test
-//    public void testReportErrors() {
-//        // Define config
-//        Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
-//        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
-//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
-//
-//        // Create mocks
-//        final TopologyContext topologyContext = new MockTopologyContext();
-//        final MockSpoutOutputCollector mockSpoutOutputCollector = new MockSpoutOutputCollector();
-//
-//        // Create spout
-//        final DynamicSpout spout = new DynamicSpout(config);
-//
-//        // Call open
-//        spout.open(config, topologyContext, mockSpoutOutputCollector);
-//
-//        // Hook into error queue, and queue some errors
-//        final Throwable exception1 = new RuntimeException("My RuntimeException");
-//        final Throwable exception2 = new Exception("My Exception");
-//
-//        // "Report" our exceptions
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//        messageBus.publishError(exception1);
-//        messageBus.publishError(exception2);
-//
-//        // Call next tuple a couple times, validate errors get reported.
-//        await()
-//            .atMost(30, TimeUnit.SECONDS)
-//            .until(() -> {
-//                // Call next tuple
-//                spout.nextTuple();
-//
-//                return mockSpoutOutputCollector.getReportedErrors().size() >= 2;
-//            });
-//
-//        // Validate
-//        final List<Throwable> reportedErrors = mockSpoutOutputCollector.getReportedErrors();
-//        assertEquals("Should have 2 reported errors", 2, reportedErrors.size());
-//        assertTrue("Contains first exception", reportedErrors.contains(exception1));
-//        assertTrue("Contains second exception", reportedErrors.contains(exception2));
-//
-//        // Call close
-//        spout.close();
-//    }
-//
-//    /**
-//     * Verifies that you do not define an output stream via the SidelineSpoutConfig
-//     * declareOutputFields() method with default to using 'default' stream.
-//     */
-//    @Test
-//    @UseDataProvider("provideOutputFields")
-//    public void testDeclareOutputFields_without_stream(final Object inputFields, final String[] expectedFields) {
-//        // Create config with null stream id config option.
-//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
-//
-//        // Define our output fields as key and value.
-//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
-//
-//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-//
-//        // Create spout, but don't call open
-//        final SidelineSpout spout = new SidelineSpout(config);
-//
-//        // call declareOutputFields
-//        spout.declareOutputFields(declarer);
-//
-//        // Validate results.
-//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-//
-//        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
-//        assertEquals(
-//            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
-//            Lists.newArrayList(expectedFields)
-//        );
-//
-//        spout.close();
-//    }
-//
-//    /**
-//     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
-//     * in the declareOutputFields() method.
-//     */
-//    @Test
-//    @UseDataProvider("provideOutputFields")
-//    public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
-//        final String streamId = "foobar";
-//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
-//
-//        // Define our output fields as key and value.
-//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
-//
-//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
-//
-//        // Create spout, but do not call open.
-//        final SidelineSpout spout = new SidelineSpout(config);
-//
-//        // call declareOutputFields
-//        spout.declareOutputFields(declarer);
-//
-//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
-//
-//        assertTrue(fieldsDeclaration.containsKey(streamId));
-//        assertEquals(
-//            fieldsDeclaration.get(streamId).get_output_fields(),
-//            Lists.newArrayList(expectedFields)
-//        );
-//
-//        spout.close();
-//    }
-//
-//    /**
-//     * Provides various inputs to be split.
-//     */
-//    @DataProvider
-//    public static Object[][] provideOutputFields() throws InstantiationException, IllegalAccessException {
-//        return new Object[][] {
-//            // String inputs, these get split and trimmed.
-//            { "key,value", new String[] {"key", "value"} },
-//            { "key, value", new String[] {"key", "value"} },
-//            { " key    , value  ,", new String[] {"key", "value"} },
-//
-//            // List of Strings, used as is.
-//            { Lists.newArrayList("key", "value"), new String[] { "key", "value"} },
-//            { Lists.newArrayList("  key  ", " value"), new String[] { "  key  ", " value"} },
-//            { Lists.newArrayList("key,value", "another"), new String[] { "key,value", "another"} },
-//
-//            // Fields inputs, used as is.
-//            { new Fields("key", "value"), new String[] { "key", "value" } },
-//            { new Fields(" key ", "    value"), new String[] { " key ", "    value" } },
-//            { new Fields("key,value ", "another"), new String[] { "key,value ", "another" } },
-//        };
-//    }
-//
-//    /**
-//     * Noop, just doing coverage!  These methods don't actually
-//     * do anything right now anyways.
-//     */
-//    @Test
-//    public void testActivate() {
-//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-//        spout.activate();
-//    }
-//
-//    /**
-//     * Noop, just doing coverage!  These methods don't actually
-//     * do anything right now anyways.
-//     */
-//    @Test
-//    public void testDeactivate() {
-//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
-//        spout.deactivate();
-//    }
-//
-//    // Helper methods
-//
-//    /**
-//     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
-//     * got emitted by the spout, and make sure everything matches up to what we expected.
-//     *
-//     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
-//     * @param spoutEmission - The SpoutEmissions we got out of the spout
-//     * @param expectedConsumerId - What consumerId these emissions should be associated with.
-//     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
-//     */
-//    private void validateEmission(
-//        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
-//        final SpoutEmission spoutEmission,
-//        final String expectedConsumerId,
-//        final String expectedOutputStreamId
-//    ) {
-//        // Now find its corresponding tuple
-//        assertNotNull("Not null sanity check", spoutEmission);
-//        assertNotNull("Not null sanity check", sourceProducerRecord);
-//
-//        // Validate Message Id
-//        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
-//        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
-//
-//        // Grab the messageId and validate it
-//        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
-//        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
-//        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
-//        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
-//
-//        // TODO: Should revisit this and refactor the test to properly pass around identifiers for validation
-//        assertEquals("Expected Source Consumer Id", expectedConsumerId, messageId.getSrcVirtualSpoutId().toString());
-//
-//        // Validate Tuple Contents
-//        List<Object> tupleValues = spoutEmission.getTuple();
-//        assertNotNull("Tuple Values should not be null", tupleValues);
-//        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
-//
-//        // For now the values in the tuple should be 'key' and 'value', this may change.
-//        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
-//        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
-//        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
-//
-//        // Validate Emit Parameters
-//        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
-//    }
-//
-//    /**
-//     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
-//     * to actually ack them before returning.
-//     *
-//     * @param spout - the Spout instance to ack tuples on.
-//     * @param spoutEmissions - The SpoutEmissions we want to ack.
-//     */
-//    private void ackTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
-//        if (spoutEmissions.isEmpty()) {
-//            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
-//        }
-//
-//        // Ack each one.
-//        for (SpoutEmission emission: spoutEmissions) {
-//            spout.ack(emission.getMessageId());
-//        }
-//
-//        // Grab reference to message bus.
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//
-//        // Acking tuples is an async process, so we need to make sure they get picked up
-//        // and processed before continuing.
-//        await()
-//            .atMost(6500, TimeUnit.MILLISECONDS)
-//            .until(() -> {
-//                // Wait for our tuples to get popped off the acked queue.
-//                return messageBus.ackSize() == 0;
-//            }, equalTo(true));
-//    }
-//
-//    /**
-//     * Utility method to fail tuples on a spout.  This will wait for the underlying VirtualSpout instance
-//     * to actually fail them before returning.
-//     *
-//     * @param spout - the Spout instance to ack tuples on.
-//     * @param spoutEmissions - The SpoutEmissions we want to ack.
-//     */
-//    private void failTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
-//        if (spoutEmissions.isEmpty()) {
-//            throw new RuntimeException("You cannot fail an empty list!  You probably have a bug in your test.");
-//        }
-//
-//        // Fail each one.
-//        for (SpoutEmission emission: spoutEmissions) {
-//            spout.fail(emission.getMessageId());
-//        }
-//
-//        // Grab reference to message bus.
-//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
-//
-//        // Failing tuples is an async process, so we need to make sure they get picked up
-//        // and processed before continuing.
-//        await()
-//            .atMost(6500, TimeUnit.MILLISECONDS)
-//            .until(() -> {
-//                // Wait for our tuples to get popped off the fail queue.
-//                return messageBus.failSize() == 0;
-//            }, equalTo(true));
-//    }
-//
-//    /**
-//     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
-//     * @param spout - The spout instance to call nextTuple() on.
-//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
-//     * @param numberOfAttempts - How many times to call nextTuple()
-//     */
-//    private void validateNextTupleEmitsNothing(
-//        DynamicSpout spout,
-//        MockSpoutOutputCollector collector,
-//        int numberOfAttempts,
-//        long delayInMs
-//    ) {
-//        try {
-//            Thread.sleep(delayInMs);
-//        } catch (InterruptedException e) {
-//            throw new RuntimeException(e);
-//        }
-//
-//        // Try a certain number of times
-//        final int originalSize = collector.getEmissions().size();
-//        for (int x = 0; x < numberOfAttempts; x++) {
-//            // Call next Tuple
-//            spout.nextTuple();
-//
-//            // If we get an unexpected emission
-//            if (originalSize != collector.getEmissions().size()) {
-//                // Lets log it
-//                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
-//            }
-//            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
-//        }
-//    }
-//
-//    /**
-//     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
-//     * @param spout - The spout instance to call nextTuple() on.
-//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
-//     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
-//     */
-//    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
-//        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
-//
-//        // Create a new list for the emissions we expect to get back
-//        List<SpoutEmission> newEmissions = Lists.newArrayList();
-//
-//        // Determine how many emissions are already in the collector
-//        final int existingEmissionsCount = collector.getEmissions().size();
-//
-//        // Call next tuple N times
-//        for (int x = 0; x < numberOfTuples; x++) {
-//            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
-//            await()
-//                .atMost(5, TimeUnit.SECONDS)
-//                .until(() -> {
-//                    // Ask for next tuple
-//                    spout.nextTuple();
-//
-//                    // Return how many tuples have been emitted so far
-//                    // It should be equal to our loop count + 1
-//                    return collector.getEmissions().size();
-//                }, equalTo(existingEmissionsCount + x + 1));
-//
-//            // Should have some emissions
-//            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
-//
-//            // Add our new emission to our return list
-//            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
-//        }
-//
-//        // Log them for reference.
-//        logger.info("Found new emissions: {}", newEmissions);
-//        return newEmissions;
-//    }
-//
-//    /**
-//     * Given a list of produced kafka messages, and a list of tuples that got emitted,
-//     * make sure that the tuples match up with what we expected to get sent out.
-//     *  @param producedRecords the original records produced into kafka.
-//     * @param spoutEmissions the tuples that got emitted out from the spout
-//     * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
-//     * @param expectedConsumerId consumer id we expected
-//     */
-//    private void validateTuplesFromSourceMessages(
-//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
-//        final List<SpoutEmission> spoutEmissions,
-//        final String expectedStreamId,
-//        final String expectedConsumerId
-//    ) {
-//        // Sanity check, make sure we have the same number of each.
-//        assertEquals(
-//            "Should have same number of tuples as original messages, Produced Count: " + producedRecords.size()
-//                + " Emissions Count: " + spoutEmissions.size(),
-//            producedRecords.size(),
-//            spoutEmissions.size()
-//        );
-//
-//        // Iterator over what got emitted
-//        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
-//
-//        // Loop over what we produced into kafka
-//        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
-//            // Now find its corresponding tuple from our iterator
-//            final SpoutEmission spoutEmission = emissionIterator.next();
-//
-//            // validate that they match
-//            validateEmission(producedRecord, spoutEmission, expectedConsumerId, expectedStreamId);
-//        }
-//    }
-//
-//    /**
-//     * Waits for virtual spouts to close out.
-//     * @param spout - The spout instance
-//     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
-//     */
-//    private void waitForVirtualSpouts(DynamicSpout spout, int howManyVirtualSpoutsWeWantLeft) {
-//        await()
-//            .atMost(5, TimeUnit.SECONDS)
-//            .until(() -> spout.getSpoutCoordinator().getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
-//        assertEquals(
-//            "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
-//            howManyVirtualSpoutsWeWantLeft,
-//            spout.getSpoutCoordinator().getTotalSpouts()
-//        );
-//    }
+    /**
+     * Our most basic End 2 End test that includes basic sidelining.
+     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
+     * Records 1 and 2 we get out of the spout.
+     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
+     * We stop sidelining, this should cause a virtual spout to be started within the spout.
+     * Calling nextTuple() should get back the records that were previously skipped.
+     * We produce additional records into the namespace.
+     * Call nextTuple() and we should get them out.
+     */
+    @Test
+    public void doTestWithSidelining() throws InterruptedException {
+        // How many records to publish into kafka per go.
+        final int numberOfRecordsToPublish = 3;
+
+        // Define our ConsumerId prefix
+        final String consumerIdPrefix = "TestSidelineSpout";
+        final VirtualSpoutIdentifier firehoseIdentifier = new DefaultVirtualSpoutIdentifier(consumerIdPrefix + ":main");
+
+        // Create our Config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix);
+
+        // Create some stand-in mocks.
+        final TopologyContext topologyContext = new MockTopologyContext();
+        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout, add references to our static trigger, and call open().
+        final SidelineSpout spout = new SidelineSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // wait for firehose vspout to start
+        waitForVirtualSpouts(spout, 1);
+
+        // Produce records into kafka
+        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+
+        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
+        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
+        // to be emitted.
+        // Grab out the emissions so we can validate them.
+        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+
+        // Validate the tuples are what we published into kafka
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, firehoseIdentifier);
+
+        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
+        ackTuples(spout, spoutEmissions);
+
+        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
+        assertTrue("Should have a single VirtualSpout instance", spout.hasVirtualSpout(firehoseIdentifier));
+
+        // Create a static message filter, this allows us to easily start filtering messages.
+        // It should filter ALL messages
+        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+        final SidelineVirtualSpoutIdentifier sidelineIdentifier = new SidelineVirtualSpoutIdentifier(consumerIdPrefix, request.id);
+
+        // Send a new start request with our filter.
+        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+        StaticTrigger.sendStartRequest(request);
+
+        // Produce another 3 records into kafka.
+        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+
+        // We basically want the time that would normally pass before we check that there are no new tuples
+        // Call next tuple, it should NOT receive any tuples because
+        // all tuples are filtered.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+
+        // Send a stop sideline request
+        StaticTrigger.sendStopRequest(request);
+
+        // Wait for the sideline vspout to start,
+        waitForVirtualSpouts(spout, 2);
+        assertTrue("Has sideline spout instance", spout.hasVirtualSpout(sidelineIdentifier));
+
+        // Then ask the spout for tuples, we should get back the tuples that were produced while
+        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
+        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+
+        // We should validate these emissions
+        validateTuplesFromSourceMessages(
+            producedRecords,
+            spoutEmissions,
+            sidelineIdentifier
+        );
+
+        // Call next tuple a few more times to be safe nothing else comes in.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
+        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
+        waitForVirtualSpouts(spout, 2);
+
+        // Lets ack our messages.
+        ackTuples(spout, spoutEmissions);
+
+        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
+        // We need to wait for the monitor thread to run to clean it up.
+        waitForVirtualSpouts(spout, 1);
+
+        // Produce some more records, verify they come in the firehose.
+        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+
+        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+
+        // Loop over what we produced into kafka and validate them
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, firehoseIdentifier);
+
+        // Close out
+        spout.close();
+    }
+
+    /**
+     * This test stands up a spout instance and tests sidelining.
+     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
+     * we stop the spout, create a new instance and restart it.  If things are working correctly
+     * the sidelined VirtualSpout should resume from where it left off.
+     */
+    @Test
+    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
+        // Produce 10 messages into kafka (offsets 0->9)
+        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+
+        // Create spout
+        // Define our output stream id
+        final String expectedStreamId = "default";
+        final String consumerIdPrefix = "TestSidelineSpout";
+        final VirtualSpoutIdentifier firehoseIdentifier = new DefaultVirtualSpoutIdentifier(consumerIdPrefix + ":main");
+
+        // Create our config
+        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix);
+
+        // Use zookeeper persistence manager
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+        config.put(
+            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
+        );
+
+        // Some mock stuff to get going
+        TopologyContext topologyContext = new MockTopologyContext();
+        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout, add references to our static trigger, and call open().
+        SidelineSpout spout = new SidelineSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
+
+        // Validate its the messages we expected
+        validateEmission(producedRecords.get(0), spoutEmissions.get(0), firehoseIdentifier, "default");
+        validateEmission(producedRecords.get(1), spoutEmissions.get(1), firehoseIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(2), spoutEmissions.get(2), firehoseIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(3), spoutEmissions.get(3), firehoseIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(4), spoutEmissions.get(4), firehoseIdentifier, expectedStreamId);
+        validateEmission(producedRecords.get(5), spoutEmissions.get(5), firehoseIdentifier, expectedStreamId);
+
+        // We will ack offsets in the following order: 2,0,1,3,5
+        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+
+        // Create a static message filter, this allows us to easily start filtering messages.
+        // It should filter ALL messages
+        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+
+        // Send a new start request with our filter.
+        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+        StaticTrigger.sendStartRequest(request);
+
+        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
+
+        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
+        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
+
+        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
+        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
+
+        // We'll validate them
+        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, firehoseIdentifier);
+
+        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
+
+        // Lets not ack any more tuples from the fire hose, that means the last completed
+        // offset on the fire hose spout should still be 3.
+
+        // Stop the spout.
+        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+        spout.close();
+
+        // A little debug log
+        logger.info("=== Starting spout again");
+        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
+
+        // Create new Spout instance and start
+        topologyContext = new MockTopologyContext();
+        spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout, add references to our static trigger, and call open().
+        spout = new SidelineSpout(config);
+
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Wait 3 seconds, then verify we have a single virtual spouts running
+        Thread.sleep(3000L);
+        waitForVirtualSpouts(spout, 1);
+
+        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
+        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
+
+        // Send a stop sideline request
+        StaticTrigger.sendStopRequest(request);
+        final SidelineVirtualSpoutIdentifier sidelineIdentifier = new SidelineVirtualSpoutIdentifier(consumerIdPrefix, request.id);
+
+        // Verify 2 VirtualSpouts are running
+        waitForVirtualSpouts(spout, 2);
+
+        // Call nextTuple() 3 times
+        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+
+        // Verify we get offsets [4,5,6] by validating the tuples
+        validateEmission(
+            producedRecords.get(4),
+            sidelinedEmissions.get(0),
+            sidelineIdentifier,
+            expectedStreamId
+        );
+        validateEmission(
+            producedRecords.get(5),
+            sidelinedEmissions.get(1),
+            sidelineIdentifier,
+            expectedStreamId
+        );
+        validateEmission(
+            producedRecords.get(6),
+            sidelinedEmissions.get(2),
+            sidelineIdentifier,
+            expectedStreamId
+        );
+
+        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
+        ackTuples(spout, sidelinedEmissions);
+
+        // Shut down spout.
+        spout.close();
+
+        // A little debug log
+        logger.info("=== Starting spout again");
+        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
+
+        // Create new spout instance and start
+        topologyContext = new MockTopologyContext();
+        spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // Create our spout, add references to our static trigger, and call open().
+        spout = new SidelineSpout(config);
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Verify we have a 2 virtual spouts running
+        waitForVirtualSpouts(spout, 2);
+
+        // Since last committed offset should be 6,
+        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
+        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
+
+        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
+        // Gather up the expected records
+        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
+        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
+        sidelineKafkaRecords.addAll(additionalProducedRecords);
+
+        // Validate em.
+        validateTuplesFromSourceMessages(
+            sidelineKafkaRecords,
+            sidelinedEmissions,
+            sidelineIdentifier
+        );
+
+        // call nextTuple() several times, get nothing back
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
+        ackTuples(spout, sidelinedEmissions);
+
+        // Verify 2nd VirtualSpout shuts off
+        waitForVirtualSpouts(spout, 1);
+        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
+
+        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
+        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
+
+        // Call nextTuple() 5 times,
+        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
+
+        // verify we get the tuples [15,16,17,18,19]
+        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, firehoseIdentifier);
+
+        // Ack offsets [15,16,18] => Committed offset should be 16
+        ackTuples(spout, Lists.newArrayList(
+            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
+        ));
+
+        // Verify no more tuples
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Stop spout
+        spout.close();
+
+        // Create new spout instance and start.
+        topologyContext = new MockTopologyContext();
+        spoutOutputCollector = new MockSpoutOutputCollector();
+
+        // A little debug log
+        logger.info("=== Starting spout for last time");
+        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
+
+
+        // Create our spout, add references to our static trigger, and call open().
+        spout = new SidelineSpout(config);
+
+        spout.open(config, topologyContext, spoutOutputCollector);
+
+        // Verify we have a single 1 virtual spouts running,
+        // This makes sure that we don't resume a previously completed sideline request.
+        Thread.sleep(3000);
+        waitForVirtualSpouts(spout, 1);
+
+        // Call nextTuple() 3 times,
+        // verify we get offsets [17,18,19]
+        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+
+        // Validate we got the right offset [17,18,19]
+        validateTuplesFromSourceMessages(
+            lastProducedRecords.subList(2,5),
+            lastSpoutEmissions,
+            firehoseIdentifier
+        );
+
+        // Verify no more tuples
+        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+
+        // Stop spout.
+        spout.close();
+    }
+
+    // Helper methods
+
+    /**
+     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
+     * got emitted by the spout, and make sure everything matches up to what we expected.
+     *
+     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
+     * @param spoutEmission - The SpoutEmissions we got out of the spout
+     * @param expectedVirtualSpoutId - What virtualSpoutId these emissions should be associated with.
+     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
+     */
+    private void validateEmission(
+        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
+        final SpoutEmission spoutEmission,
+        final VirtualSpoutIdentifier expectedVirtualSpoutId,
+        final String expectedOutputStreamId
+    ) {
+        // Now find its corresponding tuple
+        assertNotNull("Not null sanity check", spoutEmission);
+        assertNotNull("Not null sanity check", sourceProducerRecord);
+
+        // Validate Message Id
+        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
+        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
+
+        // Grab the messageId and validate it
+        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
+        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
+        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
+        assertEquals("Expected Source Consumer Id", expectedVirtualSpoutId, messageId.getSrcVirtualSpoutId());
+
+        // Validate Tuple Contents
+        List<Object> tupleValues = spoutEmission.getTuple();
+        assertNotNull("Tuple Values should not be null", tupleValues);
+        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
+
+        // For now the values in the tuple should be 'key' and 'value', this may change.
+        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
+        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
+        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
+
+        // Validate Emit Parameters
+        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
+    }
+
+    /**
+     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
+     * to actually ack them before returning.
+     *
+     * @param spout - the Spout instance to ack tuples on.
+     * @param spoutEmissions - The SpoutEmissions we want to ack.
+     */
+    private void ackTuples(final SidelineSpout spout, final List<SpoutEmission> spoutEmissions) {
+        if (spoutEmissions.isEmpty()) {
+            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
+        }
+
+        // Ack each one.
+        for (SpoutEmission emission: spoutEmissions) {
+            spout.ack(emission.getMessageId());
+        }
+
+        // Make method accessible.
+        try {
+            // TODO find better way to do this w/o reflections.
+            final Field field = spout.getClass().getDeclaredField("messageBus");
+            field.setAccessible(true);
+
+            // Grab reference to message bus.
+            final MessageBus messageBus = (MessageBus) field.get(spout);
+
+            // Acking tuples is an async process, so we need to make sure they get picked up
+            // and processed before continuing.
+            await()
+                .atMost(6500, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    // Wait for our tuples to get popped off the acked queue.
+                    return messageBus.ackSize() == 0;
+                }, equalTo(true));
+
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
+     * @param spout - The spout instance to call nextTuple() on.
+     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+     * @param numberOfAttempts - How many times to call nextTuple()
+     */
+    private void validateNextTupleEmitsNothing(
+        DynamicSpout spout,
+        MockSpoutOutputCollector collector,
+        int numberOfAttempts,
+        long delayInMs
+    ) {
+        try {
+            Thread.sleep(delayInMs);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Try a certain number of times
+        final int originalSize = collector.getEmissions().size();
+        for (int x = 0; x < numberOfAttempts; x++) {
+            // Call next Tuple
+            spout.nextTuple();
+
+            // If we get an unexpected emission
+            if (originalSize != collector.getEmissions().size()) {
+                // Lets log it
+                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
+            }
+            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
+        }
+    }
+
+    /**
+     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
+     * @param spout - The spout instance to call nextTuple() on.
+     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
+     */
+    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
+        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
+
+        // Create a new list for the emissions we expect to get back
+        List<SpoutEmission> newEmissions = Lists.newArrayList();
+
+        // Determine how many emissions are already in the collector
+        final int existingEmissionsCount = collector.getEmissions().size();
+
+        // Call next tuple N times
+        for (int x = 0; x < numberOfTuples; x++) {
+            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
+            await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> {
+                    // Ask for next tuple
+                    spout.nextTuple();
+
+                    // Return how many tuples have been emitted so far
+                    // It should be equal to our loop count + 1
+                    return collector.getEmissions().size();
+                }, equalTo(existingEmissionsCount + x + 1));
+
+            // Should have some emissions
+            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
+
+            // Add our new emission to our return list
+            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
+        }
+
+        // Log them for reference.
+        logger.info("Found new emissions: {}", newEmissions);
+        return newEmissions;
+    }
+
+    /**
+     * Given a list of produced kafka messages, and a list of tuples that got emitted,
+     * make sure that the tuples match up with what we expected to get sent out.
+     *  @param producedRecords the original records produced into kafka.
+     * @param spoutEmissions the tuples that got emitted out from the spout
+     * @param expectedVirtualSpoutId virtual spout id we expected
+     */
+    private void validateTuplesFromSourceMessages(
+        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
+        final List<SpoutEmission> spoutEmissions,
+        final VirtualSpoutIdentifier expectedVirtualSpoutId
+    ) {
+        // Sanity check, make sure we have the same number of each.
+        assertEquals(
+            "Should have same number of tuples as original messages, Produced Count: "
+            + producedRecords.size() + " Emissions Count: " + spoutEmissions.size(),
+            producedRecords.size(),
+            spoutEmissions.size()
+        );
+
+        // Iterator over what got emitted
+        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
+
+        // Loop over what we produced into kafka
+        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
+            // Now find its corresponding tuple from our iterator
+            final SpoutEmission spoutEmission = emissionIterator.next();
+
+            // validate that they match
+            validateEmission(producedRecord, spoutEmission, expectedVirtualSpoutId, "default");
+        }
+    }
+
+    /**
+     * Waits for virtual spouts to close out.
+     * @param spout - The spout instance
+     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
+     */
+    private void waitForVirtualSpouts(final SidelineSpout spout, final int howManyVirtualSpoutsWeWantLeft) {
+        try {
+            // TODO find better way to do this avoiding reflections
+            final Field field = spout.getClass().getDeclaredField("spoutCoordinator");
+            field.setAccessible(true);
+            final SpoutCoordinator spoutCoordinator = (SpoutCoordinator) field.get(spout);
+
+            await()
+                .atMost(5, TimeUnit.SECONDS)
+                .until(() -> spoutCoordinator.getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
+            assertEquals(
+                "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
+                howManyVirtualSpoutsWeWantLeft,
+                spoutCoordinator.getTotalSpouts()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
 
     /**
      * helper method to produce records into kafka.
@@ -1341,9 +698,8 @@ public class SidelineSpoutTest {
      * Generates a Storm Topology configuration with some sane values for our test scenarios.
      *
      * @param consumerIdPrefix - consumerId prefix to use.
-     * @param configuredStreamId - What streamId we should emit tuples out of.
      */
-    private Map<String, Object> getDefaultConfig(final String consumerIdPrefix, final String configuredStreamId) {
+    private Map<String, Object> getDefaultConfig(final String consumerIdPrefix) {
         // Generate a unique zkRootNode for each test
         final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
 
@@ -1364,15 +720,6 @@ public class SidelineSpoutTest {
         // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
         config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
 
-        // TODO: Separate the dependencies on this from this test!!!
-        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
-        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
-        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
-        config.put(
-            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
-            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
-        );
-
         // Configure SpoutCoordinator thread to run every 1 second
         config.put(SpoutConfig.MONITOR_THREAD_INTERVAL_MS, 1000L);
 
@@ -1382,17 +729,15 @@ public class SidelineSpoutTest {
         // For now use the Log Recorder
         config.put(SpoutConfig.METRICS_RECORDER_CLASS, LogRecorder.class.getName());
 
-        config.put(SpoutConfig.SPOUT_HANDLER_CLASS, SidelineSpoutHandler.class.getName());
-
-        config.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
-
+        // Enable sideline options
         config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
-
-        // If we have a stream Id we should be configured with
-        if (configuredStreamId != null) {
-            // Drop it into our configuration.
-            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
-        }
+        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
+        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
+        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        config.put(
+            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
+        );
 
         return config;
     }

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -85,6 +85,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Provides End-To-End integration test coverage for SidelineSpout specific functionality.
  * This test does not attempt to validate all pieces of DynamicSpout, as that is covered by DynamicSpoutTest.
+ * Although not required to use SidelineSpout, some of these tests use the Kafka consumer as a dependency to validate
+ * behavior.
  */
 @RunWith(DataProviderRunner.class)
 public class SidelineSpoutTest {

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -1,0 +1,1420 @@
+package com.salesforce.storm.spout.sideline;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.salesforce.kafka.test.KafkaTestServer;
+import com.salesforce.kafka.test.KafkaTestUtils;
+import com.salesforce.kafka.test.ProducedKafkaRecord;
+import com.salesforce.kafka.test.junit.SharedKafkaTestResource;
+import com.salesforce.storm.spout.dynamic.ConsumerPartition;
+import com.salesforce.storm.spout.dynamic.DynamicSpout;
+import com.salesforce.storm.spout.dynamic.DynamicSpoutTest;
+import com.salesforce.storm.spout.dynamic.MessageBus;
+import com.salesforce.storm.spout.dynamic.MessageId;
+import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
+import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
+import com.salesforce.storm.spout.dynamic.kafka.Consumer;
+import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
+import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
+import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
+import com.salesforce.storm.spout.dynamic.mocks.MockTopologyContext;
+import com.salesforce.storm.spout.dynamic.mocks.output.MockSpoutOutputCollector;
+import com.salesforce.storm.spout.dynamic.mocks.output.SpoutEmission;
+import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
+import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
+import com.salesforce.storm.spout.dynamic.retry.FailedTuplesFirstRetryManager;
+import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
+import com.salesforce.storm.spout.sideline.config.SidelineConfig;
+import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
+import com.salesforce.storm.spout.sideline.handler.SidelineVirtualSpoutHandler;
+import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
+import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
+import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.storm.generated.StreamInfo;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsGetter;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.Utils;
+import org.apache.zookeeper.KeeperException;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class SidelineSpoutTest {
+    // For logging within the test.
+    private static final Logger logger = LoggerFactory.getLogger(DynamicSpoutTest.class);
+
+    /**
+     * Create shared kafka test server.
+     */
+    @ClassRule
+    public static final SharedKafkaTestResource sharedKafkaTestResource = new SharedKafkaTestResource();
+
+    /**
+     * We generate a unique topic name for every test case.
+     */
+    private String topicName;
+
+    /**
+     * This happens once before every test method.
+     * Create a new empty namespace with randomly generated name.
+     */
+    @Before
+    public void beforeTest() throws InterruptedException {
+        // Generate namespace name
+        topicName = DynamicSpoutTest.class.getSimpleName() + Clock.systemUTC().millis();
+
+        // Create namespace
+        getKafkaTestServer().createTopic(topicName);
+    }
+
+//    /**
+//     * Our most simple end-2-end test.
+//     * This test stands up our spout and ask it to consume from our kafka namespace.
+//     * We publish some data into kafka, and validate that when we call nextTuple() on
+//     * our spout that we get out our messages that were published into kafka.
+//     *
+//     * This does not make use of any side lining logic, just simple consuming from the
+//     * 'fire hose' consumer.
+//     *
+//     * We run this test multiple times using a DataProvider to test using but an implicit/unconfigured
+//     * output stream name (default), as well as an explicitly configured stream name.
+//     */
+//    @Test
+//    @UseDataProvider("provideStreamIds")
+//    public void doBasicConsumingTest(final String configuredStreamId, final String expectedStreamId) throws InterruptedException {
+//        // Define how many tuples we should push into the namespace, and then consume back out.
+//        final int emitTupleCount = 10;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, null);
+//
+//        // If we have a stream Id we should be configured with
+//        if (configuredStreamId != null) {
+//            // Drop it into our configuration.
+//            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
+//        }
+//
+//        // Some mock storm topology stuff to get going
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple, namespace is empty, so nothing should get emitted.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 2, 0L);
+//
+//        // Lets produce some data into the namespace
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+//
+//        // Now consume tuples generated from the messages we published into kafka.
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//
+//        // Validate the tuples that got emitted are what we expect based on what we published into kafka
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Call next tuple a few more times to make sure nothing unexpected shows up.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 3, 0L);
+//
+//        // Cleanup.
+//        spout.close();
+//    }
+//
+//    /**
+//     * End-to-End test over the fail() method using the {@link FailedTuplesFirstRetryManager}
+//     * retry manager.
+//     *
+//     * This test stands up our spout and ask it to consume from our kafka namespace.
+//     * We publish some data into kafka, and validate that when we call nextTuple() on
+//     * our spout that we get out our messages that were published into kafka.
+//     *
+//     * We then fail some tuples and validate that they get replayed.
+//     * We ack some tuples and then validate that they do NOT get replayed.
+//     *
+//     * This does not make use of any side lining logic, just simple consuming from the
+//     * 'fire hose' namespace.
+//     */
+//    @Test
+//    public void doBasicFailTest() throws InterruptedException {
+//        // Define how many tuples we should push into the namespace, and then consume back out.
+//        final int emitTupleCount = 10;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "SidelineSpout";
+//
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Configure to use our FailedTuplesFirstRetryManager retry manager.
+//        config.put(SpoutConfig.RETRY_MANAGER_CLASS, FailedTuplesFirstRetryManager.class.getName());
+//
+//        // Some mock stuff to get going
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple, namespace is empty, so should get nothing.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Lets produce some data into the namespace
+//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(emitTupleCount, 0);
+//
+//        // Now loop and get our tuples
+//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//
+//        // Now lets validate that what we got out of the spout is what we actually expected.
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Call next tuple a few more times to make sure nothing unexpected shows up.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Now lets fail our tuples.
+//        failTuples(spout, spoutEmissions);
+//
+//        // And lets call nextTuple, and we should get the same emissions back out because we called fail on them
+//        // And our retry manager should replay them first chance it gets.
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, emitTupleCount);
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Now lets ack 2 different offsets, entries 0 and 3.
+//        // This means they should never get replayed.
+//        List<SpoutEmission> ackedEmissions = Lists.newArrayList();
+//        ackedEmissions.add(spoutEmissions.get(0));
+//        ackedEmissions.add(spoutEmissions.get(3));
+//        ackTuples(spout, ackedEmissions);
+//
+//        // And lets remove their related KafkaRecords
+//        // Remember to remove in reverse order, because ArrayLists have no gaps in indexes :p
+//        producedRecords.remove(3);
+//        producedRecords.remove(0);
+//
+//        // And lets fail the others
+//        List<SpoutEmission> failEmissions = Lists.newArrayList(spoutEmissions);
+//        failEmissions.removeAll(ackedEmissions);
+//        failTuples(spout, failEmissions);
+//
+//        // This is how many we failed.
+//        final int failedTuples = failEmissions.size();
+//
+//        // If we call nextTuple, we should get back our failed emissions
+//        final List<SpoutEmission> replayedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, failedTuples);
+//
+//        // Validate we don't get anything else
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate the replayed tuples were our failed ones
+//        validateTuplesFromSourceMessages(producedRecords, replayedEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Now lets ack these
+//        ackTuples(spout, replayedEmissions);
+//
+//        // And validate nextTuple gives us nothing new
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 100L);
+//
+//        // Cleanup.
+//        spout.close();
+//    }
+//
+//    /**
+//     * Our most basic End 2 End test that includes basic sidelining.
+//     * First we stand up our spout and produce some records into the kafka namespace its consuming from.
+//     * Records 1 and 2 we get out of the spout.
+//     * Then we enable sidelining, and call nextTuple(), the remaining records should not be emitted.
+//     * We stop sidelining, this should cause a virtual spout to be started within the spout.
+//     * Calling nextTuple() should get back the records that were previously skipped.
+//     * We produce additional records into the namespace.
+//     * Call nextTuple() and we should get them out.
+//     */
+//    @Test
+//    public void doTestWithSidelining() throws InterruptedException {
+//        // How many records to publish into kafka per go.
+//        final int numberOfRecordsToPublish = 3;
+//
+//        // Define our ConsumerId prefix
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//
+//        // Create our Config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Create some stand-in mocks.
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        final DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Produce records into kafka
+//        List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // Wait for our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+//        // Consuming from kafka is an async process de-coupled from the call to nextTuple().  Because of this it could
+//        // take several calls to nextTuple() before the messages are pulled in from kafka behind the scenes and available
+//        // to be emitted.
+//        // Grab out the emissions so we can validate them.
+//        List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // Validate the tuples are what we published into kafka
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Lets ack our tuples, this should commit offsets 0 -> 2. (0,1,2)
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Sanity test, we should have a single VirtualSpout instance at this point, the fire hose instance
+//        assertEquals("Should have a single VirtualSpout instance", 1, spout.getSpoutCoordinator().getTotalSpouts());
+//
+//        // Create a static message filter, this allows us to easily start filtering messages.
+//        // It should filter ALL messages
+//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+//
+//        // Send a new start request with our filter.
+//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+//        StaticTrigger.sendStartRequest(request);
+//
+//        // Produce another 3 records into kafka.
+//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // We basically want the time that would normally pass before we check that there are no new tuples
+//        // Call next tuple, it should NOT receive any tuples because
+//        // all tuples are filtered.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+//
+//        // Send a stop sideline request
+//        StaticTrigger.sendStopRequest(request);
+//
+//        // We need to wait a bit for the sideline spout instance to spin up
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Then ask the spout for tuples, we should get back the tuples that were produced while
+//        // sidelining was active.  These tuples should come from the VirtualSpout started by the Stop request.
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // We should validate these emissions
+//        validateTuplesFromSourceMessages(
+//            producedRecords,
+//            spoutEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":sideline:" + request.id
+//        );
+//
+//        // Call next tuple a few more times to be safe nothing else comes in.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate that VirtualSpouts are NOT closed out, but still waiting for unacked tuples.
+//        // We should have 2 instances at this point, the firehose, and 1 sidelining instance.
+//        assertEquals("We should have 2 virtual spouts running", 2, spout.getSpoutCoordinator().getTotalSpouts());
+//
+//        // Lets ack our messages.
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Validate that VirtualSpouts instance closes out once finished acking all processed tuples.
+//        // We need to wait for the monitor thread to run to clean it up.
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Produce some more records, verify they come in the firehose.
+//        producedRecords = produceRecords(numberOfRecordsToPublish, 0);
+//
+//        // Wait up to 5 seconds, our 'firehose' spout instance should pull these 3 records in when we call nextTuple().
+//        spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, numberOfRecordsToPublish);
+//
+//        // Loop over what we produced into kafka and validate them
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Close out
+//        spout.close();
+//    }
+//
+//    /**
+//     * This test stands up a spout instance and begins consuming from a namespace.
+//     * Halfway thru consuming all the messages published in that namespace we will shutdown
+//     * the spout gracefully.
+//     *
+//     * We'll create a new instance of the spout and fire it up, then validate that it resumes
+//     * consuming from where it left off.
+//     *
+//     * Assumptions made in this test:
+//     *   - single partition namespace
+//     *   - using ZK persistence manager to maintain state between spout instances/restarts.
+//     */
+//    @Test
+//    public void testResumingForFirehoseVirtualSpout() throws InterruptedException, IOException, KeeperException {
+//        // Produce 10 messages into kafka (offsets 0->9)
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Some mock stuff to get going
+//        TopologyContext topologyContext = new MockTopologyContext();
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout and call open
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+//        final List<SpoutEmission> spoutEmissions = Collections.unmodifiableList(consumeTuplesFromSpout(spout, spoutOutputCollector, 6));
+//
+//        // Validate its the messages we expected
+//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // We will ack offsets in the following order: 2,0,1,3,5
+//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // Create fresh new spoutOutputCollector & topology context
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create fresh new instance of spout & call open all with the same config
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Call next tuple to get remaining tuples out.
+//        // It should give us offsets [4,5,6,7,8,9]
+//        final List<SpoutEmission> spoutEmissionsAfterResume = Collections.unmodifiableList(
+//            consumeTuplesFromSpout(spout, spoutOutputCollector, 6)
+//        );
+//
+//        // Validate no further tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Validate its the tuples we expect [4,5,6,7,8,9]
+//        validateEmission(producedRecords.get(4), spoutEmissionsAfterResume.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissionsAfterResume.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(6), spoutEmissionsAfterResume.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(7), spoutEmissionsAfterResume.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(8), spoutEmissionsAfterResume.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(9), spoutEmissionsAfterResume.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // Ack all tuples.
+//        ackTuples(spout, spoutEmissionsAfterResume);
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // Create fresh new spoutOutputCollector & topology context
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create fresh new instance of spout & call open all with the same config
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Validate no further tuples, as we acked all the things.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
+//
+//        // And done.
+//        spout.close();
+//    }
+//
+//    /**
+//     * This test stands up a spout instance and tests sidelining.
+//     * Half way thru consuming the tuples that should be emitted from the sidelined VirtualSpout
+//     * we stop the spout, create a new instance and restart it.  If things are working correctly
+//     * the sidelined VirtualSpout should resume from where it left off.
+//     */
+//    @Test
+//    public void testResumingSpoutWhileSidelinedVirtualSpoutIsActive() throws InterruptedException {
+//        // Produce 10 messages into kafka (offsets 0->9)
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords = Collections.unmodifiableList(produceRecords(10, 0));
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//        config.put(
+//            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+//            com.salesforce.storm.spout.sideline.persistence.ZookeeperPersistenceAdapter.class.getName()
+//        );
+//
+//        // Some mock stuff to get going
+//        TopologyContext topologyContext = new MockTopologyContext();
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Call next tuple 6 times, getting offsets 0,1,2,3,4,5
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 6);
+//
+//        // Validate its the messages we expected
+//        validateEmission(producedRecords.get(0), spoutEmissions.get(0), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(1), spoutEmissions.get(1), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(2), spoutEmissions.get(2), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(3), spoutEmissions.get(3), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(4), spoutEmissions.get(4), consumerIdPrefix + ":main", expectedStreamId);
+//        validateEmission(producedRecords.get(5), spoutEmissions.get(5), consumerIdPrefix + ":main", expectedStreamId);
+//
+//        // We will ack offsets in the following order: 2,0,1,3,5
+//        // This should give us a completed offset of [0,1,2,3] <-- last committed offset should be 3
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(2)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(0)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(1)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(3)));
+//        ackTuples(spout, Lists.newArrayList(spoutEmissions.get(5)));
+//
+//        // Create a static message filter, this allows us to easily start filtering messages.
+//        // It should filter ALL messages
+//        final SidelineRequest request = new SidelineRequest(new SidelineRequestIdentifier("test"), new StaticMessageFilter());
+//
+//        // Send a new start request with our filter.
+//        // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
+//        StaticTrigger.sendStartRequest(request);
+//
+//        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
+//
+//        // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
+//        final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
+//
+//        // Call nextTuple() 4 more times, we should get the remaining first 10 records because they were already buffered.
+//        spoutEmissions.addAll(consumeTuplesFromSpout(spout, spoutOutputCollector, 4));
+//
+//        // We'll validate them
+//        validateTuplesFromSourceMessages(producedRecords, spoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // But if we call nextTuple() 5 more times, we should never get the additional 5 records we produced.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 100L);
+//
+//        // Lets not ack any more tuples from the fire hose, that means the last completed
+//        // offset on the fire hose spout should still be 3.
+//
+//        // Stop the spout.
+//        // A graceful shutdown of the spout should have the consumer state flushed to the persistence layer.
+//        spout.close();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout again");
+//        logger.info("=== This verifies that when we resume, we pickup started sideling requests and continue filtering");
+//
+//        // Create new Spout instance and start
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Wait 3 seconds, then verify we have a single virtual spouts running
+//        Thread.sleep(3000L);
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call nextTuple() 20 times, we should get no tuples, last committed offset was 3, so this means we asked for
+//        // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
+//
+//        // Send a stop sideline request
+//        StaticTrigger.sendStopRequest(request);
+//
+//        // Verify 2 VirtualSpouts are running
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Call nextTuple() 3 times
+//        List<SpoutEmission> sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+//
+//        // Verify we get offsets [4,5,6] by validating the tuples
+//        validateEmission(
+//            producedRecords.get(4),
+//            sidelinedEmissions.get(0),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//        validateEmission(
+//            producedRecords.get(5),
+//            sidelinedEmissions.get(1),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//        validateEmission(
+//            producedRecords.get(6),
+//            sidelinedEmissions.get(2),
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier,
+//            expectedStreamId
+//        );
+//
+//        // Ack offsets [4,5,6] => committed offset should be 6 now on sideline consumer.
+//        ackTuples(spout, sidelinedEmissions);
+//
+//        // Shut down spout.
+//        spout.close();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout again");
+//        logger.info("=== This verifies that when we resume a side line virtual spout, we resume at the proper offset based on state");
+//
+//        // Create new spout instance and start
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Verify we have a 2 virtual spouts running
+//        waitForVirtualSpouts(spout, 2);
+//
+//        // Since last committed offset should be 6,
+//        // Call nextTuple() 8 times to get offsets [7,8,9,10,11,12,13,14]
+//        sidelinedEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 8);
+//
+//        // Verify we get offsets [7,8,9,10,11,12,13,14] by validating the tuples
+//        // Gather up the expected records
+//        List<ProducedKafkaRecord<byte[], byte[]>> sidelineKafkaRecords = Lists.newArrayList();
+//        sidelineKafkaRecords.addAll(producedRecords.subList(7, 10));
+//        sidelineKafkaRecords.addAll(additionalProducedRecords);
+//
+//        // Validate em.
+//        validateTuplesFromSourceMessages(
+//            sidelineKafkaRecords,
+//            sidelinedEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":sideline:" + sidelineRequestIdentifier
+//        );
+//
+//        // call nextTuple() several times, get nothing back
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Ack offsets [4,5,6,7,8,9,10,11,12,13,14] => committed offset should be 14 now on sideline consumer.
+//        ackTuples(spout, sidelinedEmissions);
+//
+//        // Verify 2nd VirtualSpout shuts off
+//        waitForVirtualSpouts(spout, 1);
+//        logger.info("=== Virtual Spout should be closed now... just fire hose left!");
+//
+//        // Produce 5 messages into Kafka namespace with offsets [15,16,17,18,19]
+//        List<ProducedKafkaRecord<byte[], byte[]>> lastProducedRecords = produceRecords(5, 0);
+//
+//        // Call nextTuple() 5 times,
+//        List<SpoutEmission> lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 5);
+//
+//        // verify we get the tuples [15,16,17,18,19]
+//        validateTuplesFromSourceMessages(lastProducedRecords, lastSpoutEmissions, expectedStreamId, consumerIdPrefix + ":main");
+//
+//        // Ack offsets [15,16,18] => Committed offset should be 16
+//        ackTuples(spout, Lists.newArrayList(
+//            lastSpoutEmissions.get(0), lastSpoutEmissions.get(1), lastSpoutEmissions.get(3)
+//        ));
+//
+//        // Verify no more tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Stop spout
+//        spout.close();
+//
+//        // Create new spout instance and start.
+//        topologyContext = new MockTopologyContext();
+//        spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // A little debug log
+//        logger.info("=== Starting spout for last time");
+//        logger.info("=== This last bit verifies that we don't resume finished sideline requests");
+//
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        spout = new SidelineSpout(config);
+//
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // Verify we have a single 1 virtual spouts running,
+//        // This makes sure that we don't resume a previously completed sideline request.
+//        Thread.sleep(3000);
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call nextTuple() 3 times,
+//        // verify we get offsets [17,18,19]
+//        lastSpoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, 3);
+//
+//        // Validate we got the right offset [17,18,19]
+//        validateTuplesFromSourceMessages(
+//            lastProducedRecords.subList(2,5),
+//            lastSpoutEmissions,
+//            expectedStreamId,
+//            consumerIdPrefix + ":main"
+//        );
+//
+//        // Verify no more tuples
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 0L);
+//
+//        // Stop spout.
+//        spout.close();
+//    }
+//
+//    /**
+//     * This is an integration test of multiple SidelineConsumers.
+//     * We stand up a namespace with 4 partitions.
+//     * We then have a consumer size of 2.
+//     * We run the test once using consumerIndex 0
+//     *   - Verify we only consume from partitions 0 and 1
+//     * We run the test once using consumerIndex 1
+//     *   - Verify we only consume from partitions 2 and 3
+//     * @param taskIndex What taskIndex to run the test with.
+//     */
+//    @Test
+//    @UseDataProvider("providerOfTaskIds")
+//    public void testConsumeWithConsumerGroupEvenNumberOfPartitions(final int taskIndex) {
+//        final int numberOfMsgsPerPartition = 10;
+//
+//        // Create a namespace with 4 partitions
+//        topicName = "testConsumeWithConsumerGroupEvenNumberOfPartitions" + Clock.systemUTC().millis();
+//        getKafkaTestServer().createTopic(topicName, 4);
+//
+//        // Define some topicPartitions
+//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+//
+//        // produce 10 msgs into even partitions, 11 into odd partitions
+//        produceRecords(numberOfMsgsPerPartition, 0);
+//        produceRecords(numberOfMsgsPerPartition + 1, 1);
+//        produceRecords(numberOfMsgsPerPartition, 2);
+//        produceRecords(numberOfMsgsPerPartition + 1, 3);
+//
+//        // Some initial setup
+//        final List<ConsumerPartition> expectedPartitions;
+//        if (taskIndex == 0) {
+//            // If we're consumerIndex 0, we expect partitionIds 0 or 1
+//            expectedPartitions = Lists.newArrayList(partition0 , partition1);
+//        } else if (taskIndex == 1) {
+//            // If we're consumerIndex 0, we expect partitionIds 2 or 3
+//            expectedPartitions = Lists.newArrayList(partition2 , partition3);
+//        } else {
+//            throw new RuntimeException("Invalid input to test");
+//        }
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Create topology context, set our task index
+//        MockTopologyContext topologyContext = new MockTopologyContext();
+//        topologyContext.taskId = taskIndex;
+//        topologyContext.taskIndex = taskIndex;
+//
+//        // Say that we have 2 tasks, ids 0 and 1
+//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
+//
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Wait for our virtual spout to start
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call next tuple 21 times, getting offsets 0-9 on the first partition, 0-10 on the 2nd partition
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, (numberOfMsgsPerPartition * 2) + 1);
+//
+//        // Validate they all came from the correct partitions
+//        for (SpoutEmission spoutEmission : spoutEmissions) {
+//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+//
+//            // Validate it came from the right place
+//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+//        }
+//
+//        // Validate we don't have any other emissions
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+//
+//        // Lets ack our tuples
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Close
+//        spout.close();
+//    }
+//
+//    /**
+//     * This is an integration test of multiple SidelineConsumers.
+//     * We stand up a namespace with 4 partitions.
+//     * We then have a consumer size of 2.
+//     * We run the test once using consumerIndex 0
+//     *   - Verify we only consume from partitions 0 and 1
+//     * We run the test once using consumerIndex 1
+//     *   - Verify we only consume from partitions 2 and 3
+//     * @param taskIndex What taskIndex to run the test with.
+//     */
+//    @Test
+//    @UseDataProvider("providerOfTaskIds")
+//    public void testConsumeWithConsumerGroupOddNumberOfPartitions(final int taskIndex) {
+//        final int numberOfMsgsPerPartition = 10;
+//
+//        // Create a namespace with 4 partitions
+//        topicName = "testConsumeWithConsumerGroupOddNumberOfPartitions" + Clock.systemUTC().millis();
+//        getKafkaTestServer().createTopic(topicName, 5);
+//
+//        // Define some topicPartitions
+//        final ConsumerPartition partition0 = new ConsumerPartition(topicName, 0);
+//        final ConsumerPartition partition1 = new ConsumerPartition(topicName, 1);
+//        final ConsumerPartition partition2 = new ConsumerPartition(topicName, 2);
+//        final ConsumerPartition partition3 = new ConsumerPartition(topicName, 3);
+//        final ConsumerPartition partition4 = new ConsumerPartition(topicName, 4);
+//
+//        // produce 10 msgs into even partitions, 11 into odd partitions
+//        produceRecords(numberOfMsgsPerPartition, 0);
+//        produceRecords(numberOfMsgsPerPartition + 1, 1);
+//        produceRecords(numberOfMsgsPerPartition, 2);
+//        produceRecords(numberOfMsgsPerPartition + 1, 3);
+//        produceRecords(numberOfMsgsPerPartition, 4);
+//
+//        // Some initial setup
+//        final List<ConsumerPartition> expectedPartitions;
+//        final int expectedNumberOfTuplesToConsume;
+//        if (taskIndex == 0) {
+//            // If we're consumerIndex 0, we expect partitionIds 0,1, or 2
+//            expectedPartitions = Lists.newArrayList(partition0 , partition1, partition2);
+//
+//            // We expect to get out 31 tuples
+//            expectedNumberOfTuplesToConsume = 31;
+//        } else if (taskIndex == 1) {
+//            // If we're consumerIndex 0, we expect partitionIds 3 or 4
+//            expectedPartitions = Lists.newArrayList(partition3 , partition4);
+//
+//            // We expect to get out 21 tuples
+//            expectedNumberOfTuplesToConsume = 21;
+//        } else {
+//            throw new RuntimeException("Invalid input to test");
+//        }
+//
+//        // Create spout
+//        // Define our output stream id
+//        final String expectedStreamId = "default";
+//        final String consumerIdPrefix = "TestSidelineSpout";
+//
+//        // Create our config
+//        final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
+//
+//        // Use zookeeper persistence manager
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+//
+//        // Create topology context, set our task index
+//        MockTopologyContext topologyContext = new MockTopologyContext();
+//        topologyContext.taskId = taskIndex;
+//        topologyContext.taskIndex = taskIndex;
+//
+//        // Say that we have 2 tasks, ids 0 and 1
+//        topologyContext.componentTasks = Collections.unmodifiableList(Lists.newArrayList(0,1));
+//
+//        MockSpoutOutputCollector spoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create our spout, add references to our static trigger, and call open().
+//        DynamicSpout spout = new SidelineSpout(config);
+//        spout.open(config, topologyContext, spoutOutputCollector);
+//
+//        // validate our streamId
+//        assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
+//
+//        // Wait for our virtual spout to start
+//        waitForVirtualSpouts(spout, 1);
+//
+//        // Call next tuple , getting offsets 0-9 on the even partitions, 0-10 on the odd partitions
+//        final List<SpoutEmission> spoutEmissions = consumeTuplesFromSpout(spout, spoutOutputCollector, expectedNumberOfTuplesToConsume);
+//
+//        // Validate they all came from the correct partitions
+//        for (SpoutEmission spoutEmission : spoutEmissions) {
+//            assertNotNull("Has non-null tupleId", spoutEmission.getMessageId());
+//
+//            // Validate it came from the right place
+//            final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//            final ConsumerPartition consumerPartition = new ConsumerPartition(messageId.getNamespace(), messageId.getPartition());
+//            assertTrue("Came from expected partition", expectedPartitions.contains(consumerPartition));
+//        }
+//
+//        // Validate we don't have any other emissions
+//        validateNextTupleEmitsNothing(spout, spoutOutputCollector, 5, 0L);
+//
+//        // Lets ack our tuples
+//        ackTuples(spout, spoutEmissions);
+//
+//        // Close
+//        spout.close();
+//    }
+//
+//    /**
+//     * Provides task ids 0 and 1.
+//     */
+//    @DataProvider
+//    public static Object[][] providerOfTaskIds() {
+//        return new Object[][]{
+//            {0},
+//            {1}
+//        };
+//    }
+//
+//    /**
+//     * Tests that pending errors get reported via OutputCollector.
+//     */
+//    @Test
+//    public void testReportErrors() {
+//        // Define config
+//        Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
+//        config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, "ConsumerIdPrefix");
+//        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
+//
+//        // Create mocks
+//        final TopologyContext topologyContext = new MockTopologyContext();
+//        final MockSpoutOutputCollector mockSpoutOutputCollector = new MockSpoutOutputCollector();
+//
+//        // Create spout
+//        final DynamicSpout spout = new DynamicSpout(config);
+//
+//        // Call open
+//        spout.open(config, topologyContext, mockSpoutOutputCollector);
+//
+//        // Hook into error queue, and queue some errors
+//        final Throwable exception1 = new RuntimeException("My RuntimeException");
+//        final Throwable exception2 = new Exception("My Exception");
+//
+//        // "Report" our exceptions
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//        messageBus.publishError(exception1);
+//        messageBus.publishError(exception2);
+//
+//        // Call next tuple a couple times, validate errors get reported.
+//        await()
+//            .atMost(30, TimeUnit.SECONDS)
+//            .until(() -> {
+//                // Call next tuple
+//                spout.nextTuple();
+//
+//                return mockSpoutOutputCollector.getReportedErrors().size() >= 2;
+//            });
+//
+//        // Validate
+//        final List<Throwable> reportedErrors = mockSpoutOutputCollector.getReportedErrors();
+//        assertEquals("Should have 2 reported errors", 2, reportedErrors.size());
+//        assertTrue("Contains first exception", reportedErrors.contains(exception1));
+//        assertTrue("Contains second exception", reportedErrors.contains(exception2));
+//
+//        // Call close
+//        spout.close();
+//    }
+//
+//    /**
+//     * Verifies that you do not define an output stream via the SidelineSpoutConfig
+//     * declareOutputFields() method with default to using 'default' stream.
+//     */
+//    @Test
+//    @UseDataProvider("provideOutputFields")
+//    public void testDeclareOutputFields_without_stream(final Object inputFields, final String[] expectedFields) {
+//        // Create config with null stream id config option.
+//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", null);
+//
+//        // Define our output fields as key and value.
+//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
+//
+//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+//
+//        // Create spout, but don't call open
+//        final SidelineSpout spout = new SidelineSpout(config);
+//
+//        // call declareOutputFields
+//        spout.declareOutputFields(declarer);
+//
+//        // Validate results.
+//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+//
+//        assertTrue(fieldsDeclaration.containsKey(Utils.DEFAULT_STREAM_ID));
+//        assertEquals(
+//            fieldsDeclaration.get(Utils.DEFAULT_STREAM_ID).get_output_fields(),
+//            Lists.newArrayList(expectedFields)
+//        );
+//
+//        spout.close();
+//    }
+//
+//    /**
+//     * Verifies that you can define an output stream via the SidelineSpoutConfig and it gets used
+//     * in the declareOutputFields() method.
+//     */
+//    @Test
+//    @UseDataProvider("provideOutputFields")
+//    public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
+//        final String streamId = "foobar";
+//        final Map<String,Object> config = getDefaultConfig("SidelineSpout-", streamId);
+//
+//        // Define our output fields as key and value.
+//        config.put(SpoutConfig.OUTPUT_FIELDS, inputFields);
+//
+//        final OutputFieldsGetter declarer = new OutputFieldsGetter();
+//
+//        // Create spout, but do not call open.
+//        final SidelineSpout spout = new SidelineSpout(config);
+//
+//        // call declareOutputFields
+//        spout.declareOutputFields(declarer);
+//
+//        final Map<String, StreamInfo> fieldsDeclaration = declarer.getFieldsDeclaration();
+//
+//        assertTrue(fieldsDeclaration.containsKey(streamId));
+//        assertEquals(
+//            fieldsDeclaration.get(streamId).get_output_fields(),
+//            Lists.newArrayList(expectedFields)
+//        );
+//
+//        spout.close();
+//    }
+//
+//    /**
+//     * Provides various inputs to be split.
+//     */
+//    @DataProvider
+//    public static Object[][] provideOutputFields() throws InstantiationException, IllegalAccessException {
+//        return new Object[][] {
+//            // String inputs, these get split and trimmed.
+//            { "key,value", new String[] {"key", "value"} },
+//            { "key, value", new String[] {"key", "value"} },
+//            { " key    , value  ,", new String[] {"key", "value"} },
+//
+//            // List of Strings, used as is.
+//            { Lists.newArrayList("key", "value"), new String[] { "key", "value"} },
+//            { Lists.newArrayList("  key  ", " value"), new String[] { "  key  ", " value"} },
+//            { Lists.newArrayList("key,value", "another"), new String[] { "key,value", "another"} },
+//
+//            // Fields inputs, used as is.
+//            { new Fields("key", "value"), new String[] { "key", "value" } },
+//            { new Fields(" key ", "    value"), new String[] { " key ", "    value" } },
+//            { new Fields("key,value ", "another"), new String[] { "key,value ", "another" } },
+//        };
+//    }
+//
+//    /**
+//     * Noop, just doing coverage!  These methods don't actually
+//     * do anything right now anyways.
+//     */
+//    @Test
+//    public void testActivate() {
+//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+//        spout.activate();
+//    }
+//
+//    /**
+//     * Noop, just doing coverage!  These methods don't actually
+//     * do anything right now anyways.
+//     */
+//    @Test
+//    public void testDeactivate() {
+//        final SidelineSpout spout = new SidelineSpout(Maps.newHashMap());
+//        spout.deactivate();
+//    }
+//
+//    // Helper methods
+//
+//    /**
+//     * Given a list of KafkaRecords that got published into Kafka, compare it against a list of SpoutEmissions that
+//     * got emitted by the spout, and make sure everything matches up to what we expected.
+//     *
+//     * @param sourceProducerRecord - The KafkaRecord messages published into kafka.
+//     * @param spoutEmission - The SpoutEmissions we got out of the spout
+//     * @param expectedConsumerId - What consumerId these emissions should be associated with.
+//     * @param expectedOutputStreamId - What stream these emissions should have been emitted down.
+//     */
+//    private void validateEmission(
+//        final ProducedKafkaRecord<byte[], byte[]> sourceProducerRecord,
+//        final SpoutEmission spoutEmission,
+//        final String expectedConsumerId,
+//        final String expectedOutputStreamId
+//    ) {
+//        // Now find its corresponding tuple
+//        assertNotNull("Not null sanity check", spoutEmission);
+//        assertNotNull("Not null sanity check", sourceProducerRecord);
+//
+//        // Validate Message Id
+//        assertNotNull("Should have non-null messageId", spoutEmission.getMessageId());
+//        assertTrue("Should be instance of MessageId", spoutEmission.getMessageId() instanceof MessageId);
+//
+//        // Grab the messageId and validate it
+//        final MessageId messageId = (MessageId) spoutEmission.getMessageId();
+//        assertEquals("Expected Topic Name in MessageId", sourceProducerRecord.getTopic(), messageId.getNamespace());
+//        assertEquals("Expected PartitionId found", sourceProducerRecord.getPartition(), messageId.getPartition());
+//        assertEquals("Expected MessageOffset found", sourceProducerRecord.getOffset(), messageId.getOffset());
+//
+//        // TODO: Should revisit this and refactor the test to properly pass around identifiers for validation
+//        assertEquals("Expected Source Consumer Id", expectedConsumerId, messageId.getSrcVirtualSpoutId().toString());
+//
+//        // Validate Tuple Contents
+//        List<Object> tupleValues = spoutEmission.getTuple();
+//        assertNotNull("Tuple Values should not be null", tupleValues);
+//        assertFalse("Tuple Values should not be empty", tupleValues.isEmpty());
+//
+//        // For now the values in the tuple should be 'key' and 'value', this may change.
+//        assertEquals("Should have 2 values in the tuple", 2, tupleValues.size());
+//        assertEquals("Found expected 'key' value", new String(sourceProducerRecord.getKey(), Charsets.UTF_8), tupleValues.get(0));
+//        assertEquals("Found expected 'value' value", new String(sourceProducerRecord.getValue(), Charsets.UTF_8), tupleValues.get(1));
+//
+//        // Validate Emit Parameters
+//        assertEquals("Got expected streamId", expectedOutputStreamId, spoutEmission.getStreamId());
+//    }
+//
+//    /**
+//     * Utility method to ack tuples on a spout.  This will wait for the underlying VirtualSpout instance
+//     * to actually ack them before returning.
+//     *
+//     * @param spout - the Spout instance to ack tuples on.
+//     * @param spoutEmissions - The SpoutEmissions we want to ack.
+//     */
+//    private void ackTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+//        if (spoutEmissions.isEmpty()) {
+//            throw new RuntimeException("You cannot ack an empty list!  You probably have a bug in your test.");
+//        }
+//
+//        // Ack each one.
+//        for (SpoutEmission emission: spoutEmissions) {
+//            spout.ack(emission.getMessageId());
+//        }
+//
+//        // Grab reference to message bus.
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//
+//        // Acking tuples is an async process, so we need to make sure they get picked up
+//        // and processed before continuing.
+//        await()
+//            .atMost(6500, TimeUnit.MILLISECONDS)
+//            .until(() -> {
+//                // Wait for our tuples to get popped off the acked queue.
+//                return messageBus.ackSize() == 0;
+//            }, equalTo(true));
+//    }
+//
+//    /**
+//     * Utility method to fail tuples on a spout.  This will wait for the underlying VirtualSpout instance
+//     * to actually fail them before returning.
+//     *
+//     * @param spout - the Spout instance to ack tuples on.
+//     * @param spoutEmissions - The SpoutEmissions we want to ack.
+//     */
+//    private void failTuples(final DynamicSpout spout, List<SpoutEmission> spoutEmissions) {
+//        if (spoutEmissions.isEmpty()) {
+//            throw new RuntimeException("You cannot fail an empty list!  You probably have a bug in your test.");
+//        }
+//
+//        // Fail each one.
+//        for (SpoutEmission emission: spoutEmissions) {
+//            spout.fail(emission.getMessageId());
+//        }
+//
+//        // Grab reference to message bus.
+//        final MessageBus messageBus = (MessageBus) spout.getMessageBus();
+//
+//        // Failing tuples is an async process, so we need to make sure they get picked up
+//        // and processed before continuing.
+//        await()
+//            .atMost(6500, TimeUnit.MILLISECONDS)
+//            .until(() -> {
+//                // Wait for our tuples to get popped off the fail queue.
+//                return messageBus.failSize() == 0;
+//            }, equalTo(true));
+//    }
+//
+//    /**
+//     * Utility method that calls nextTuple() on the passed in spout, and then validates that it never emitted anything.
+//     * @param spout - The spout instance to call nextTuple() on.
+//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+//     * @param numberOfAttempts - How many times to call nextTuple()
+//     */
+//    private void validateNextTupleEmitsNothing(
+//        DynamicSpout spout,
+//        MockSpoutOutputCollector collector,
+//        int numberOfAttempts,
+//        long delayInMs
+//    ) {
+//        try {
+//            Thread.sleep(delayInMs);
+//        } catch (InterruptedException e) {
+//            throw new RuntimeException(e);
+//        }
+//
+//        // Try a certain number of times
+//        final int originalSize = collector.getEmissions().size();
+//        for (int x = 0; x < numberOfAttempts; x++) {
+//            // Call next Tuple
+//            spout.nextTuple();
+//
+//            // If we get an unexpected emission
+//            if (originalSize != collector.getEmissions().size()) {
+//                // Lets log it
+//                logger.error("Got an unexpected emission: {}", collector.getEmissions().get(collector.getEmissions().size() - 1));
+//            }
+//            assertEquals("No new tuple emits on iteration " + (x + 1), originalSize, collector.getEmissions().size());
+//        }
+//    }
+//
+//    /**
+//     * Utility method that calls nextTuple() on the passed in spout, and then returns new tuples that the spout emitted.
+//     * @param spout - The spout instance to call nextTuple() on.
+//     * @param collector - The spout's output collector that would receive the tuples if any were emitted.
+//     * @param numberOfTuples - How many new tuples we expect to get out of the spout instance.
+//     */
+//    private List<SpoutEmission> consumeTuplesFromSpout(DynamicSpout spout, MockSpoutOutputCollector collector, int numberOfTuples) {
+//        logger.info("[TEST] Attempting to consume {} tuples from spout", numberOfTuples);
+//
+//        // Create a new list for the emissions we expect to get back
+//        List<SpoutEmission> newEmissions = Lists.newArrayList();
+//
+//        // Determine how many emissions are already in the collector
+//        final int existingEmissionsCount = collector.getEmissions().size();
+//
+//        // Call next tuple N times
+//        for (int x = 0; x < numberOfTuples; x++) {
+//            // Async call spout.nextTuple() because it can take a bit to fill the buffer.
+//            await()
+//                .atMost(5, TimeUnit.SECONDS)
+//                .until(() -> {
+//                    // Ask for next tuple
+//                    spout.nextTuple();
+//
+//                    // Return how many tuples have been emitted so far
+//                    // It should be equal to our loop count + 1
+//                    return collector.getEmissions().size();
+//                }, equalTo(existingEmissionsCount + x + 1));
+//
+//            // Should have some emissions
+//            assertEquals("SpoutOutputCollector should have emissions", (existingEmissionsCount + x + 1), collector.getEmissions().size());
+//
+//            // Add our new emission to our return list
+//            newEmissions.add(collector.getEmissions().get(existingEmissionsCount + x));
+//        }
+//
+//        // Log them for reference.
+//        logger.info("Found new emissions: {}", newEmissions);
+//        return newEmissions;
+//    }
+//
+//    /**
+//     * Given a list of produced kafka messages, and a list of tuples that got emitted,
+//     * make sure that the tuples match up with what we expected to get sent out.
+//     *  @param producedRecords the original records produced into kafka.
+//     * @param spoutEmissions the tuples that got emitted out from the spout
+//     * @param expectedStreamId the stream id that we expected the tuples to get emitted out on.
+//     * @param expectedConsumerId consumer id we expected
+//     */
+//    private void validateTuplesFromSourceMessages(
+//        final List<ProducedKafkaRecord<byte[], byte[]>> producedRecords,
+//        final List<SpoutEmission> spoutEmissions,
+//        final String expectedStreamId,
+//        final String expectedConsumerId
+//    ) {
+//        // Sanity check, make sure we have the same number of each.
+//        assertEquals(
+//            "Should have same number of tuples as original messages, Produced Count: " + producedRecords.size()
+//                + " Emissions Count: " + spoutEmissions.size(),
+//            producedRecords.size(),
+//            spoutEmissions.size()
+//        );
+//
+//        // Iterator over what got emitted
+//        final Iterator<SpoutEmission> emissionIterator = spoutEmissions.iterator();
+//
+//        // Loop over what we produced into kafka
+//        for (ProducedKafkaRecord<byte[], byte[]> producedRecord: producedRecords) {
+//            // Now find its corresponding tuple from our iterator
+//            final SpoutEmission spoutEmission = emissionIterator.next();
+//
+//            // validate that they match
+//            validateEmission(producedRecord, spoutEmission, expectedConsumerId, expectedStreamId);
+//        }
+//    }
+//
+//    /**
+//     * Waits for virtual spouts to close out.
+//     * @param spout - The spout instance
+//     * @param howManyVirtualSpoutsWeWantLeft - Wait until this many virtual spouts are left running.
+//     */
+//    private void waitForVirtualSpouts(DynamicSpout spout, int howManyVirtualSpoutsWeWantLeft) {
+//        await()
+//            .atMost(5, TimeUnit.SECONDS)
+//            .until(() -> spout.getSpoutCoordinator().getTotalSpouts(), equalTo(howManyVirtualSpoutsWeWantLeft));
+//        assertEquals(
+//            "We should have " + howManyVirtualSpoutsWeWantLeft + " virtual spouts running",
+//            howManyVirtualSpoutsWeWantLeft,
+//            spout.getSpoutCoordinator().getTotalSpouts()
+//        );
+//    }
+
+    /**
+     * helper method to produce records into kafka.
+     */
+    private List<ProducedKafkaRecord<byte[], byte[]>> produceRecords(int numberOfRecords, int partitionId) {
+        KafkaTestUtils kafkaTestUtils = new KafkaTestUtils(getKafkaTestServer());
+        return kafkaTestUtils.produceRecords(numberOfRecords, topicName, partitionId);
+    }
+
+    /**
+     * Generates a Storm Topology configuration with some sane values for our test scenarios.
+     *
+     * @param consumerIdPrefix - consumerId prefix to use.
+     * @param configuredStreamId - What streamId we should emit tuples out of.
+     */
+    private Map<String, Object> getDefaultConfig(final String consumerIdPrefix, final String configuredStreamId) {
+        // Generate a unique zkRootNode for each test
+        final String uniqueZkRootNode = "/sideline-spout-test/testRun" + System.currentTimeMillis();
+
+        final Map<String, Object> config = SpoutConfig.setDefaults(SidelineConfig.setDefaults(Maps.newHashMap()));
+
+        // Kafka Consumer config items
+        config.put(SpoutConfig.CONSUMER_CLASS, Consumer.class.getName());
+        config.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
+        config.put(KafkaConsumerConfig.KAFKA_TOPIC, topicName);
+        config.put(KafkaConsumerConfig.CONSUMER_ID_PREFIX, consumerIdPrefix);
+        config.put(KafkaConsumerConfig.KAFKA_BROKERS, Lists.newArrayList(getKafkaTestServer().getKafkaConnectString()));
+
+        // DynamicSpout config items
+        config.put(SpoutConfig.RETRY_MANAGER_CLASS, NeverRetryManager.class.getName());
+        config.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
+        config.put(SpoutConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
+
+        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        config.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
+
+        // TODO: Separate the dependencies on this from this test!!!
+        config.put(SidelineConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
+        config.put(SidelineConfig.PERSISTENCE_ZK_ROOT, uniqueZkRootNode);
+        // Use In Memory Persistence manager, if you need state persistence, over ride this in your test.
+        config.put(
+            SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
+            com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()
+        );
+
+        // Configure SpoutCoordinator thread to run every 1 second
+        config.put(SpoutConfig.MONITOR_THREAD_INTERVAL_MS, 1000L);
+
+        // Configure flushing consumer state every 1 second
+        config.put(SpoutConfig.CONSUMER_STATE_FLUSH_INTERVAL_MS, 1000L);
+
+        // For now use the Log Recorder
+        config.put(SpoutConfig.METRICS_RECORDER_CLASS, LogRecorder.class.getName());
+
+        config.put(SpoutConfig.SPOUT_HANDLER_CLASS, SidelineSpoutHandler.class.getName());
+
+        config.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
+
+        config.put(SidelineConfig.TRIGGER_CLASS, StaticTrigger.class.getName());
+
+        // If we have a stream Id we should be configured with
+        if (configuredStreamId != null) {
+            // Drop it into our configuration.
+            config.put(SpoutConfig.OUTPUT_STREAM_ID, configuredStreamId);
+        }
+
+        return config;
+    }
+
+    /**
+     * Provides various StreamIds to test emitting out of.
+     */
+    @DataProvider
+    public static Object[][] provideStreamIds() {
+        return new Object[][]{
+            // No explicitly defined streamId should use the default streamId.
+            { null, Utils.DEFAULT_STREAM_ID },
+
+            // Explicitly defined streamId should get used as is.
+            { "SpecialStreamId", "SpecialStreamId" }
+        };
+    }
+
+    /**
+     * Simple accessor.
+     */
+    private KafkaTestServer getKafkaTestServer() {
+        return sharedKafkaTestResource.getKafkaTestServer();
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -34,7 +34,7 @@ import com.salesforce.storm.spout.dynamic.VirtualSpout;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.kafka.KafkaConsumerConfig;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
-import com.salesforce.storm.spout.dynamic.consumer.MockConsumer;
+import com.salesforce.storm.spout.dynamic.mocks.MockConsumer;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.dynamic.filter.NegatingFilterChainStep;
 import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
@@ -27,7 +27,7 @@ package com.salesforce.storm.spout.sideline.handler;
 
 import com.google.common.collect.Maps;
 import com.salesforce.storm.spout.sideline.SidelineVirtualSpoutIdentifier;
-import com.salesforce.storm.spout.dynamic.consumer.MockConsumer;
+import com.salesforce.storm.spout.dynamic.mocks.MockConsumer;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
 import com.salesforce.storm.spout.dynamic.mocks.MockDelegateSpout;

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
@@ -30,7 +30,7 @@ import com.google.gson.GsonBuilder;
 import com.salesforce.kafka.test.junit.SharedZookeeperTestResource;
 import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
-import com.salesforce.storm.spout.dynamic.consumer.MockConsumer;
+import com.salesforce.storm.spout.dynamic.mocks.MockConsumer;
 import com.salesforce.storm.spout.dynamic.filter.FilterChainStep;
 import com.salesforce.storm.spout.dynamic.filter.StaticMessageFilter;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorFactory;
@@ -48,7 +48,6 @@ import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
Start to breakup the integration test DynamicSpoutTest into:
- DynamicSpoutTest - Covering DynamicSpout using a stand-in MockConsumer (and no sidelining logic)

- SidelineSpoutTest - Covering just the Sidelining functionality, makes use of KafkaConsumer to help validate various scenarios.  

- KafkaConsumerTest - Integration test covering the KafkaConsumer within DynamicSpout, covers no sidelining logic.

This moves us towards being able to do #19 