### PR TITLE
Remove metric from VirtualSpout API

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
@@ -103,13 +103,6 @@ public interface DelegateSpout {
     ConsumerState getEndingState();
 
     /**
-     * Get the number of filters applied to spout's filter chain. Used for metrics in the spout monitor.
-     * TODO Should we drop this metric? This feels out of place in the interface.
-     * @return Number of filters applied.
-     */
-    int getNumberOfFiltersApplied();
-
-    /**
      * Get the Consumer this spout is using to pull messages from.
      * @return Consumer instance.
      */

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -256,6 +256,8 @@ public class VirtualSpout implements DelegateSpout {
      */
     @Override
     public Message nextTuple() {
+        getMetricsRecorder().assignValue(getClass(), getVirtualSpoutId() + ".filters", getFilterChain().getSteps().size());
+
         // Start total Time timer.
         getMetricsRecorder().startTimer(getClass(), "nextTuple.entireMethod");
 
@@ -320,7 +322,7 @@ public class VirtualSpout implements DelegateSpout {
         // Keep Track of the tuple in this spout somewhere so we can replay it if it happens to fail.
         if (isFiltered) {
             // Increment filtered metric
-            getMetricsRecorder().count(VirtualSpout.class, getVirtualSpoutId() + ".filtered");
+            getMetricsRecorder().count(getClass(), getVirtualSpoutId() + ".filtered");
 
             // Ack
             ack(messageId);
@@ -433,7 +435,7 @@ public class VirtualSpout implements DelegateSpout {
             consumer.commitOffset(messageId.getNamespace(), messageId.getPartition(), messageId.getOffset());
 
             // Update metric
-            getMetricsRecorder().count(VirtualSpout.class, getVirtualSpoutId() + ".exceeded_retry_limit");
+            getMetricsRecorder().count(getClass(), getVirtualSpoutId() + ".exceeded_retry_limit");
 
             // Done.
             return;
@@ -443,7 +445,7 @@ public class VirtualSpout implements DelegateSpout {
         retryManager.failed(messageId);
 
         // Update metric
-        getMetricsRecorder().count(VirtualSpout.class, getVirtualSpoutId() + ".fail");
+        getMetricsRecorder().count(getClass(), getVirtualSpoutId() + ".fail");
     }
 
     /**
@@ -517,11 +519,6 @@ public class VirtualSpout implements DelegateSpout {
 
     public ConsumerState getEndingState() {
         return endingState;
-    }
-
-    @Override
-    public int getNumberOfFiltersApplied() {
-        return getFilterChain().getSteps().size();
     }
 
     public Map<String, Object> getSpoutConfig() {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -430,12 +430,6 @@ public class SpoutCoordinator implements Runnable {
                 getSpoutPartitionProgressMonitor().reportStatus(
                     spout
                 );
-
-                // Report how many filters are applied on this virtual spout.
-                getMetricsRecorder().assignValue(
-                    VirtualSpout.class,
-                    spout.getVirtualSpoutId() + ".number_filters_applied", spout.getNumberOfFiltersApplied()
-                );
             }
         } catch (final Throwable throwable) {
             // report the error up.

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -127,11 +127,6 @@ public class MockDelegateSpout implements DelegateSpout {
     }
 
     @Override
-    public int getNumberOfFiltersApplied() {
-        return 0;
-    }
-
-    @Override
     public Consumer getConsumer() {
         return new MockConsumer();
     }


### PR DESCRIPTION
I want to keep the VirtualSpout (and really the DelegateSpout interface) as minimal as possible. Whenever we have a method that's public for stuff like this I think we need to re-evaluate it and consider dropping it if possible. Thus, this metric is being moved into the VirtualSpout and I am dropping it from the interface.