### PR TITLE
Dropping requestStop() from the DelegateSpout

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
@@ -75,17 +75,6 @@ public interface DelegateSpout {
     void flushState();
 
     /**
-     * Request that the current spout stop running for async shutdown.
-     */
-    void requestStop();
-
-    /**
-     * Has the current spout been told to stop?
-     * @return True if it has, false if it has not.
-     */
-    boolean isStopRequested();
-
-    /**
      * Get the current ConsumerState from this spout's Consumer instance.
      * @return Current ConsumerState.
      */
@@ -121,4 +110,12 @@ public interface DelegateSpout {
      * @return filter chain instance.
      */
     FilterChain getFilterChain();
+
+    /**
+     * Whether or not this {@link VirtualSpout} has completed it's processing, which typically means that the data from {@link Consumer},
+     * specifically {@link #getCurrentState()} is now at or beyond {@link #getEndingState()}.
+     *
+     * @return true is the spout is finished processing, false if it is not.
+     */
+    boolean isCompleted();
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -104,12 +104,6 @@ public class VirtualSpout implements DelegateSpout {
     private boolean isOpened = false;
 
     /**
-     * This flag is used to signal for this instance to cleanly stop.
-     * Marked as volatile because currently its accessed via multiple threads.
-     */
-    private volatile boolean requestedStop = false;
-
-    /**
      * This flag represents when we have finished consuming all that needs to be consumed.
      */
     private boolean isCompleted = false;
@@ -445,35 +439,13 @@ public class VirtualSpout implements DelegateSpout {
     }
 
     /**
-     * Call this method to request this {@link VirtualSpout} instance
-     * to cleanly stop.
+     * Whether or not this {@link VirtualSpout} has completed it's processing, which typically means that the data from {@link Consumer},
+     * specifically {@link #getCurrentState()} is now at or beyond {@link #getEndingState()}.
      *
-     * Synchronized because this can be called from multiple threads.
+     * @return true is the spout is finished processing, false if it is not.
      */
-    public void requestStop() {
-        synchronized (this) {
-            requestedStop = true;
-        }
-    }
-
-    /**
-     * Determine if anyone has requested stop on this instance.
-     * Synchronized because this can be called from multiple threads.
-     *
-     * @return - true if so, false if not.
-     */
-    public boolean isStopRequested() {
-        synchronized (this) {
-            return requestedStop || Thread.interrupted();
-        }
-    }
-
-    /**
-     * This this method to determine if the spout was marked as 'completed'.
-     * We define 'completed' meaning it reached its ending state.
-     * @return - True if 'completed', false if not.
-     */
-    private boolean isCompleted() {
+    @Override
+    public boolean isCompleted() {
         return isCompleted;
     }
 
@@ -640,9 +612,5 @@ public class VirtualSpout implements DelegateSpout {
         // Lets flip our flag to true.
         logger.info("Looks like all partitions are complete!  Lets wrap this up.");
         setCompleted();
-
-        // Cleanup consumerState.
-        // Request that we stop.
-        requestStop();
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinatorTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinatorTest.java
@@ -244,8 +244,7 @@ public class SpoutCoordinatorTest {
     }
 
     /**
-     * Test what happens when a running spout instance finishes "normally" by
-     * requesting it to stop.
+     * Test what happens when a running spout instance finishes "normally".
      */
     @Test
     public void testWhatHappensWhenSpoutClosesNormally() throws InterruptedException, ExecutionException {
@@ -257,7 +256,6 @@ public class SpoutCoordinatorTest {
 
         // Create a mock spout
         MockDelegateSpout mockSpout = new MockDelegateSpout(new DefaultVirtualSpoutIdentifier("MySpoutId"));
-        mockSpout.requestedStop = false;
 
         // Add it to our queue
         spoutCoordinator.addVirtualSpout(mockSpout);
@@ -276,8 +274,8 @@ public class SpoutCoordinatorTest {
         // validate the executor is running it
         assertEquals("Should have 1 running task", 1, spoutCoordinator.getExecutor().getActiveCount());
 
-        // Make the mock spout stop.
-        mockSpout.requestStop();
+        // Mark the spout as completed, the coordinator will see this and should shut it down
+        mockSpout.completed = true;
 
         // Wait for spout count to decrease
         await()
@@ -423,8 +421,8 @@ public class SpoutCoordinatorTest {
         final MockDelegateSpout notStartedSpout = mockSpouts.get(mockSpouts.size() - 1);
         assertFalse("Should not have called open on our spout thats not running", notStartedSpout.wasOpenCalled);
 
-        // Now stop the first instance
-        mockSpouts.get(0).requestStop();
+        // Now stop the first instance by setting completed = true
+        mockSpouts.get(0).completed = true;
 
         // Wait for it to be closed
         await()
@@ -584,7 +582,6 @@ public class SpoutCoordinatorTest {
 
         // Create a mock spout
         MockDelegateSpout mockSpout = new MockDelegateSpout(new DefaultVirtualSpoutIdentifier("MySpoutId"));
-        mockSpout.requestedStop = false;
 
         // Add it to our queue
         spoutCoordinator.addVirtualSpout(mockSpout);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunnerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutRunnerTest.java
@@ -207,8 +207,8 @@ public class SpoutRunnerTest {
 
         // Shut down
         if (shutdownViaSpout) {
-            logger.info("Requesting stop via Spout.requestStop()");
-            mockSpout.requestStop();
+            logger.info("Requesting stop via Spout.isCompleted()");
+            mockSpout.completed = true;
         } else {
             logger.info("Requesting stop via SpoutRunner.requestStop()");
             spoutRunner.requestStop();

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -46,14 +46,13 @@ import java.util.UUID;
 public class MockDelegateSpout implements DelegateSpout {
     private final VirtualSpoutIdentifier virtualSpoutId;
     private final FilterChain filterChain = new FilterChain();
-    public volatile boolean requestedStop = false;
+    public volatile boolean completed = false;
     public volatile boolean wasOpenCalled = false;
     public volatile boolean wasCloseCalled = false;
     public volatile boolean flushStateCalled = false;
     public volatile RuntimeException exceptionToThrow = null;
     public volatile Set<MessageId> failedTupleIds = Sets.newConcurrentHashSet();
     public volatile Set<MessageId> ackedTupleIds = Sets.newConcurrentHashSet();
-
     public volatile Queue<Message> emitQueue = Queues.newConcurrentLinkedQueue();
 
     public MockDelegateSpout() {
@@ -103,16 +102,6 @@ public class MockDelegateSpout implements DelegateSpout {
     }
 
     @Override
-    public synchronized void requestStop() {
-        requestedStop = true;
-    }
-
-    @Override
-    public synchronized boolean isStopRequested() {
-        return requestedStop;
-    }
-
-    @Override
     public ConsumerState getCurrentState() {
         return getConsumer().getCurrentState();
     }
@@ -145,5 +134,10 @@ public class MockDelegateSpout implements DelegateSpout {
     @Override
     public FilterChain getFilterChain() {
         return filterChain;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return completed;
     }
 }


### PR DESCRIPTION
I would contend that the tiers of SpoutRunner -> VirtualSpout around isStopRequested() are a bit of a smell. I think what we were doing in VirtualSpout was actually the isCompleted() method, but we hadn't exposed it.  Basically, we wanted a way for the VirtualSpout to indicate it was done processing and that it could be automatically removed from the coordinator.

Additionally, I think the addition of removeVirtualSpout() elsewhere handles the scenario of "kill this VirtualSpout early" and is a much cleaner interface for doing so.