### PR TITLE
Allow ending state to be set after a VirtualSpout has been created

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
@@ -103,6 +103,13 @@ public interface DelegateSpout {
     ConsumerState getEndingState();
 
     /**
+     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     *
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     */
+    void setEndingState(ConsumerState endingState);
+
+    /**
      * Get the number of filters applied to spout's filter chain. Used for metrics in the spout monitor.
      * TODO Should we drop this metric? This feels out of place in the interface.
      * @return Number of filters applied.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -503,6 +503,7 @@ public class VirtualSpout implements DelegateSpout {
      * Get the spout's current consumer state.
      * @return current consumer state
      */
+    @Override
     public ConsumerState getCurrentState() {
         // This could happen is someone tries calling this method before the vspout is opened
         if (consumer == null) {
@@ -511,12 +512,24 @@ public class VirtualSpout implements DelegateSpout {
         return consumer.getCurrentState();
     }
 
+    @Override
     public ConsumerState getStartingState() {
         return startingState;
     }
 
+    @Override
     public ConsumerState getEndingState() {
         return endingState;
+    }
+
+    /**
+     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     *
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     */
+    @Override
+    public void setEndingState(final ConsumerState endingState) {
+        this.endingState = endingState;
     }
 
     @Override

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -1609,6 +1609,53 @@ public class VirtualSpoutTest {
     }
 
     /**
+     * Test that ending state can be set after the {@link VirtualSpout} is opened.
+     */
+    @Test
+    public void testSetEndingState() {
+        // Create inputs
+        final Map topologyConfig = getDefaultConfig();
+        final TopologyContext mockTopologyContext = new MockTopologyContext();
+        final RetryManager mockRetryManager = mock(RetryManager.class);
+
+        // Create a mock SidelineConsumer
+        final Consumer mockConsumer = mock(Consumer.class);
+
+        // Create factory manager
+        final FactoryManager mockFactoryManager = createMockFactoryManager(null, mockRetryManager, null, null);
+        when(mockFactoryManager.createNewConsumerInstance()).thenReturn(mockConsumer);
+
+        // Create spout & open
+        final VirtualSpout virtualSpout = new VirtualSpout(
+            new DefaultVirtualSpoutIdentifier("MyConsumerId"),
+            topologyConfig,
+            mockTopologyContext,
+            mockFactoryManager,
+            new LogRecorder(),
+            ConsumerState.builder().build(),
+            // Ending state here is explicitly set to null
+            null
+        );
+        virtualSpout.open();
+
+        assertNull("Ending state is not null", virtualSpout.getEndingState());
+
+        final ConsumerState endingState = ConsumerState
+            .builder()
+            .withPartition("Test", 0, 100L)
+            .build()
+        ;
+
+        virtualSpout.setEndingState(endingState);
+
+        assertEquals(
+            "Ending state does not match the one that was set",
+            endingState,
+            virtualSpout.getEndingState()
+        );
+    }
+
+    /**
      * Utility method to generate a standard config map.
      */
     private Map<String, Object> getDefaultConfig() {

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -126,6 +126,17 @@ public class MockDelegateSpout implements DelegateSpout {
         return MockConsumer.buildConsumerState(MockConsumer.partitions);
     }
 
+    /**
+     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     *
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     */
+    @Override
+    public void setEndingState(final ConsumerState endingState) {
+        // NOOP for now, this should be improved with getStartingState() and getEndingState()
+    }
+
+
     @Override
     public int getNumberOfFiltersApplied() {
         return 0;


### PR DESCRIPTION
This is being added so that you can create an open ended spout, meaning one where you don't yet know the ending state but might need to set it down the road.  This is the first step in moving our sideline implementation to support what's been called 'throttling'.