### PR TITLE
Use a factory to create VirtualSpout instances

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpoutFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpoutFactory.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic;
+
+import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
+
+/**
+ * Factory for easily creating {@link DelegateSpout} instances.
+ *
+ * Handy in things like {@link com.salesforce.storm.spout.dynamic.handler.SpoutHandler} where we want to abstract away particulars, such
+ * as the things passed down from {@link DynamicSpout} such as the {@link MetricsRecorder} as an example.
+ */
+public interface DelegateSpoutFactory {
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    <T extends DelegateSpout> T create(
+        final VirtualSpoutIdentifier identifier
+    );
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @param startingState starting consumer state for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    <T extends DelegateSpout> T create(
+        final VirtualSpoutIdentifier identifier,
+        final ConsumerState startingState
+    );
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @param startingState starting consumer state for this instance.
+     * @param endingState ending consumer state for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    <T extends DelegateSpout> T create(
+        final VirtualSpoutIdentifier identifier,
+        final ConsumerState startingState,
+        final ConsumerState endingState
+    );
+}

--- a/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
@@ -129,7 +129,7 @@ public class FactoryManager implements Serializable {
     }
 
     private synchronized <T> T createNewInstanceFromConfig(final String configKey) {
-        Preconditions.checkArgument(
+        Preconditions.checkState(
             spoutConfig.containsKey(configKey),
             "Class has not been specified for configuration key " + configKey
         );

--- a/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.storm.spout.dynamic;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.consumer.Consumer;
@@ -66,8 +67,8 @@ public class FactoryManager implements Serializable {
      * @return returns a new instance of the configured RetryManager.
      */
     public RetryManager createNewFailedMsgRetryManagerInstance() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.RETRY_MANAGER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.RETRY_MANAGER_CLASS
         );
     }
 
@@ -75,8 +76,8 @@ public class FactoryManager implements Serializable {
      * @return returns a new instance of the configured persistence manager.
      */
     public PersistenceAdapter createNewPersistenceAdapterInstance() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.PERSISTENCE_ADAPTER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.PERSISTENCE_ADAPTER_CLASS
         );
     }
 
@@ -84,8 +85,8 @@ public class FactoryManager implements Serializable {
      * @return returns a new instance of the configured Metrics Recorder manager.
      */
     public MetricsRecorder createNewMetricsRecorder() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.METRICS_RECORDER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.METRICS_RECORDER_CLASS
         );
     }
 
@@ -93,8 +94,8 @@ public class FactoryManager implements Serializable {
      * @return returns a new instance of the configured MessageBuffer interface.
      */
     public MessageBuffer createNewMessageBufferInstance() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.TUPLE_BUFFER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.TUPLE_BUFFER_CLASS
         );
     }
 
@@ -102,8 +103,8 @@ public class FactoryManager implements Serializable {
      * @return returns a new instance of the configured Consumer interface.
      */
     public Consumer createNewConsumerInstance() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.CONSUMER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.CONSUMER_CLASS
         );
     }
 
@@ -112,8 +113,8 @@ public class FactoryManager implements Serializable {
      * @return Instance of a SpoutHandler
      */
     public SpoutHandler createSpoutHandler() {
-        return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.SPOUT_HANDLER_CLASS)
+        return createNewInstanceFromConfig(
+            SpoutConfig.SPOUT_HANDLER_CLASS
         );
     }
 
@@ -122,8 +123,19 @@ public class FactoryManager implements Serializable {
      * @return Instance of a VirtualSpoutHandler
      */
     public synchronized VirtualSpoutHandler createVirtualSpoutHandler() {
+        return createNewInstanceFromConfig(
+            SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS
+        );
+    }
+
+    private synchronized <T> T createNewInstanceFromConfig(final String configKey) {
+        Preconditions.checkArgument(
+            spoutConfig.containsKey(configKey),
+            "Class has not been specified for configuration key " + configKey
+        );
+
         return createNewInstance(
-            (String) spoutConfig.get(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS)
+            (String) spoutConfig.get(configKey)
         );
     }
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactory.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactory.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic;
+
+import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
+import org.apache.storm.task.TopologyContext;
+
+import java.util.Map;
+
+/**
+ * Factory for easily creating {@link DelegateSpout} instances.
+ *
+ * Handy in things like {@link com.salesforce.storm.spout.dynamic.handler.SpoutHandler} where we want to abstract away particulars, such
+ * as the things passed down from {@link DynamicSpout} such as the {@link MetricsRecorder} as an example.
+ */
+public class VirtualSpoutFactory implements DelegateSpoutFactory {
+
+    /**
+     * Spout configuration.
+     */
+    private final Map<String, Object> spoutConfig;
+    /**
+     * Topology context.
+     */
+    private final TopologyContext topologyContext;
+    /**
+     * Factory manager, for creating instances of classes driven by configuration.
+     */
+    private final FactoryManager factoryManager;
+    /**
+     * Metrics recorder, for capturing metrics.
+     */
+    private final MetricsRecorder metricsRecorder;
+
+    /**
+     * Factory for easily creating {@link DelegateSpout} instances.
+     *
+     * Handy in things like {@link com.salesforce.storm.spout.dynamic.handler.SpoutHandler} where we want to abstract away particulars, such
+     * as the things passed down from {@link DynamicSpout} such as the {@link MetricsRecorder} as an example.
+     */
+    public VirtualSpoutFactory(
+        final Map<String, Object> spoutConfig,
+        final TopologyContext topologyContext,
+        final FactoryManager factoryManager,
+        final MetricsRecorder metricsRecorder
+    ) {
+        this.spoutConfig = spoutConfig;
+        this.topologyContext = topologyContext;
+        this.factoryManager = factoryManager;
+        this.metricsRecorder = metricsRecorder;
+    }
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @param startingState starting consumer state for this instance.
+     * @param endingState ending consumer state for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    @Override
+    public VirtualSpout create(
+        final VirtualSpoutIdentifier identifier,
+        final ConsumerState startingState,
+        final ConsumerState endingState
+    ) {
+        return new VirtualSpout(
+            identifier,
+            this.spoutConfig,
+            this.topologyContext,
+            this.factoryManager,
+            this.metricsRecorder,
+            startingState,
+            endingState
+        );
+    }
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @param startingState starting consumer state for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    @Override
+    public VirtualSpout create(
+        final VirtualSpoutIdentifier identifier,
+        final ConsumerState startingState
+    ) {
+        return create(identifier, startingState, null);
+    }
+
+    /**
+     * Create a {@link DelegateSpout} instance.
+     * @param identifier identifier to use for this instance.
+     * @return instance of {@link DelegateSpout}.
+     */
+    @Override
+    public VirtualSpout create(
+        final VirtualSpoutIdentifier identifier
+    ) {
+        return create(identifier, null, null);
+    }
+}

--- a/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
@@ -26,6 +26,7 @@
 package com.salesforce.storm.spout.dynamic.config;
 
 import com.google.common.collect.Maps;
+import com.salesforce.storm.spout.dynamic.VirtualSpoutFactory;
 import com.salesforce.storm.spout.dynamic.config.annotation.Documentation;
 import com.salesforce.storm.spout.dynamic.handler.NoopSpoutHandler;
 import com.salesforce.storm.spout.dynamic.handler.NoopVirtualSpoutHandler;
@@ -393,6 +394,13 @@ public class SpoutConfig {
     )
     public static final String VIRTUAL_SPOUT_HANDLER_CLASS = "spout.virtual_spout_handler_class";
 
+    @Documentation(
+        description = "Defines which DelegateSpoutFactory implementation to use. "
+        + "Should be a fully qualified class path that implements the DelegateSpoutFactory interface.",
+        type = String.class
+    )
+    public static final String VIRTUAL_SPOUT_FACTORY_CLASS = "spout.virtual_spout_factory_class";
+
     /**
      * Logger for logging logs.
      */
@@ -568,6 +576,15 @@ public class SpoutConfig {
                 "Unspecified configuration value for {} using default value {}",
                 VIRTUAL_SPOUT_HANDLER_CLASS,
                 clonedConfig.get(VIRTUAL_SPOUT_HANDLER_CLASS)
+            );
+        }
+
+        if (!clonedConfig.containsKey(VIRTUAL_SPOUT_FACTORY_CLASS)) {
+            clonedConfig.put(VIRTUAL_SPOUT_FACTORY_CLASS, VirtualSpoutFactory.class);
+            logger.info(
+                "Unspecified configuration value for {} using default value {}",
+                VIRTUAL_SPOUT_FACTORY_CLASS,
+                clonedConfig.get(VIRTUAL_SPOUT_FACTORY_CLASS)
             );
         }
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/handler/SpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/handler/SpoutHandler.java
@@ -25,6 +25,8 @@
 
 package com.salesforce.storm.spout.dynamic.handler;
 
+import com.salesforce.storm.spout.dynamic.DelegateSpout;
+import com.salesforce.storm.spout.dynamic.DelegateSpoutFactory;
 import com.salesforce.storm.spout.dynamic.DynamicSpout;
 import org.apache.storm.task.TopologyContext;
 
@@ -39,8 +41,9 @@ public interface SpoutHandler {
     /**
      * Open the handler.
      * @param spoutConfig Spout configuration.
+     * @param delegateSpoutFactory Factory for creating {@link DelegateSpout} instances.
      */
-    default void open(Map<String, Object> spoutConfig) {
+    default void open(Map<String, Object> spoutConfig, DelegateSpoutFactory delegateSpoutFactory) {
 
     }
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -141,10 +141,12 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
             "Sideline persistence adapter class is required"
         );
 
-        persistenceAdapter = FactoryManager.createNewInstance(
+        this.persistenceAdapter = FactoryManager.createNewInstance(
             persistenceAdapterClass
         );
-        persistenceAdapter.open(spoutConfig);
+        this.persistenceAdapter.open(spoutConfig);
+
+        this.delegateSpoutFactory = delegateSpoutFactory;
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactoryTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactoryTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic;
+
+import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
+import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
+import com.salesforce.storm.spout.dynamic.metrics.MetricsRecorder;
+import com.salesforce.storm.spout.dynamic.mocks.MockTopologyContext;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test that the factory correctly create {@link VirtualSpout instances}.
+ */
+public class VirtualSpoutFactoryTest {
+
+    /**
+     * Test that the factory correctly create {@link VirtualSpout instances}.
+     */
+    @Test
+    public void testCreate() {
+        final Map config = new HashMap<>();
+        final MockTopologyContext topologyContext = new MockTopologyContext();
+        final FactoryManager factoryManager = new FactoryManager(config);
+        final MetricsRecorder metricsRecorder = new LogRecorder();
+
+        final VirtualSpoutFactory virtualSpoutFactory = new VirtualSpoutFactory(
+            config,
+            topologyContext,
+            factoryManager,
+            metricsRecorder
+        );
+
+        final VirtualSpoutIdentifier identifier = new DefaultVirtualSpoutIdentifier("test");
+
+        final ConsumerState startingState = ConsumerState.builder()
+            .withPartition(new ConsumerPartition("foo", 0), 42L)
+            .build();
+
+        final ConsumerState endingState = ConsumerState.builder()
+            .withPartition(new ConsumerPartition("bar", 1), 72L)
+            .build();
+
+        final VirtualSpout virtualSpout = virtualSpoutFactory.create(identifier, startingState, endingState);
+
+        assertEquals(
+            "Config doesn't match",
+            config,
+            virtualSpout.getSpoutConfig()
+        );
+
+        assertEquals(
+            "Topology context does not match",
+            topologyContext,
+            virtualSpout.getTopologyContext()
+        );
+
+        assertEquals(
+            "Factory manager does not match",
+            factoryManager,
+            virtualSpout.getFactoryManager()
+        );
+
+        assertEquals(
+            "Metrics recorder does not match",
+            metricsRecorder,
+            virtualSpout.getMetricsRecorder()
+        );
+
+        assertEquals(
+            "Starting state does not match",
+            startingState,
+            virtualSpout.getStartingState()
+        );
+
+        assertEquals(
+            "Ending state does not match",
+            endingState,
+            virtualSpout.getEndingState()
+        );
+    }
+
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactoryTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutFactoryTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test that the factory correctly create {@link VirtualSpout instances}.
@@ -46,7 +46,7 @@ public class VirtualSpoutFactoryTest {
      */
     @Test
     public void testCreate() {
-        final Map config = new HashMap<>();
+        final Map<String,Object> config = new HashMap<>();
         final MockTopologyContext topologyContext = new MockTopologyContext();
         final FactoryManager factoryManager = new FactoryManager(config);
         final MetricsRecorder metricsRecorder = new LogRecorder();
@@ -106,5 +106,4 @@ public class VirtualSpoutFactoryTest {
             virtualSpout.getEndingState()
         );
     }
-
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -622,7 +622,7 @@ public class SidelineSpoutHandlerTest {
     }
 
     private VirtualSpoutFactory getVirtualSpoutFactory(final Map<String,Object> config) {
-        return new VirtualSpoutFactory(null, new MockTopologyContext(), new FactoryManager(config), new LogRecorder());
+        return new VirtualSpoutFactory(config, new MockTopologyContext(), new FactoryManager(config), new LogRecorder());
     }
 
     private Map<String, Object> getConfig() {

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -26,6 +26,9 @@
 package com.salesforce.storm.spout.sideline.handler;
 
 import com.salesforce.storm.spout.dynamic.DynamicSpout;
+import com.salesforce.storm.spout.dynamic.FactoryManager;
+import com.salesforce.storm.spout.dynamic.VirtualSpoutFactory;
+import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
 import com.salesforce.storm.spout.sideline.SidelineVirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.VirtualSpout;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
@@ -74,8 +77,10 @@ public class SidelineSpoutHandlerTest {
     public void testOpen() {
         final Map<String, Object> config = getConfig();
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
 
         assertEquals(
             config,
@@ -99,8 +104,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
         sidelineSpoutHandler.onSpoutOpen(spout, new HashMap(), new MockTopologyContext());
 
         assertNotNull(sidelineSpoutHandler.getFireHoseSpout());
@@ -134,8 +141,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
 
         final PersistenceAdapter persistenceAdapter = sidelineSpoutHandler.getPersistenceAdapter();
 
@@ -200,8 +209,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
 
         final PersistenceAdapter persistenceAdapter = sidelineSpoutHandler.getPersistenceAdapter();
 
@@ -265,8 +276,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
 
         final PersistenceAdapter persistenceAdapter = sidelineSpoutHandler.getPersistenceAdapter();
 
@@ -345,8 +358,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
         sidelineSpoutHandler.onSpoutOpen(spout, new HashMap(), new MockTopologyContext());
 
         assertNotNull(sidelineSpoutHandler.getSidelineTriggers());
@@ -374,8 +389,10 @@ public class SidelineSpoutHandlerTest {
         // Override our trigger class with one that does not actually exist.
         config.put(SidelineConfig.TRIGGER_CLASS, "FooBar" + System.currentTimeMillis());
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
 
         expectedExceptionMisconfiguredCreateStartingTrigger.expect(RuntimeException.class);
 
@@ -402,9 +419,11 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         // Create our handler
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
         sidelineSpoutHandler.onSpoutOpen(spout, new HashMap(), new MockTopologyContext());
 
         final VirtualSpoutIdentifier virtualSpoutIdentifier = sidelineSpoutHandler.generateSidelineVirtualSpoutId(
@@ -436,8 +455,10 @@ public class SidelineSpoutHandlerTest {
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
+        final VirtualSpoutFactory virtualSpoutFactory = getVirtualSpoutFactory(config);
+
         final SidelineSpoutHandler sidelineSpoutHandler = new SidelineSpoutHandler();
-        sidelineSpoutHandler.open(config);
+        sidelineSpoutHandler.open(config, virtualSpoutFactory);
         sidelineSpoutHandler.onSpoutOpen(spout, new HashMap(), new MockTopologyContext());
 
         assertTrue(
@@ -598,6 +619,10 @@ public class SidelineSpoutHandlerTest {
         // aforementioned lack of accessibility to non-firehose spouts.
         sidelineSpoutHandler.close();
         spout.close();
+    }
+
+    private VirtualSpoutFactory getVirtualSpoutFactory(final Map<String,Object> config) {
+        return new VirtualSpoutFactory(null, new MockTopologyContext(), new FactoryManager(config), new LogRecorder());
     }
 
     private Map<String, Object> getConfig() {


### PR DESCRIPTION
IMO this is related to #70 as you can tell by some of the naming weirdness.

`FactoryManager` doesn't have any facilities for passing arguments to a constructor, which is why it was not used to create the `VirtualSpoutFactory`.

I have mixed feelings about the generics in `DelegateSpoutFactory`, in the end if this is not done we wind up casting, so I think this is a better option honestly.

Note that right now the `FilterChain` is part of `VirtualSpout` and not of `DelegateSpout`, I think this is worth calling out because it is the primary reason why someone would want to directly type against `VirtualSpout` today. Perhaps we should reconsider this, I'm open to this - we just need to make a decision that the `FilterChain` is a first class citizen in the interface and that we expect implementations to utilize this.