### PR TITLE
Switch to using ConsumerPartition for sideline persistence

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -234,8 +234,6 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
             );
         }
 
-        final String topic = (String) getSpoutConfig().get(KafkaConsumerConfig.KAFKA_TOPIC);
-
         final List<SidelineRequestIdentifier> existingRequestIds = getPersistenceAdapter().listSidelineRequests();
         logger.info("Found {} existing sideline requests that need to be resumed", existingRequestIds.size());
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandler.java
@@ -83,7 +83,7 @@ public class SidelineVirtualSpoutHandler implements VirtualSpoutHandler {
                 for (final ConsumerPartition consumerPartition : virtualSpout.getStartingState().getConsumerPartitions()) {
                     persistenceAdapter.clearSidelineRequest(
                         sidelineRequestIdentifier,
-                        consumerPartition.partition()
+                        consumerPartition
                     );
                 }
             }

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/PersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/PersistenceAdapter.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.storm.spout.sideline.persistence;
 
+import com.salesforce.storm.spout.dynamic.ConsumerPartition;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import com.salesforce.storm.spout.sideline.trigger.SidelineType;
@@ -54,7 +55,7 @@ public interface PersistenceAdapter {
      * @param type type of the sideline (Start/Stop).
      * @param id unique identifier for the sideline request.
      * @param request sideline request.
-     * @param partitionId Partition id
+     * @param consumerPartition consumer partition.
      * @param startingOffset Ending offset
      * @param endingOffset Starting offset
      */
@@ -62,7 +63,7 @@ public interface PersistenceAdapter {
         final SidelineType type,
         final SidelineRequestIdentifier id,
         final SidelineRequest request,
-        final int partitionId,
+        final ConsumerPartition consumerPartition,
         final Long startingOffset,
         final Long endingOffset
     );
@@ -70,24 +71,24 @@ public interface PersistenceAdapter {
     /**
      * Retrieves a sideline request state for the given SidelineRequestIdentifier.
      * @param id SidelineRequestIdentifier you want to retrieve the state for.
-     * @param partitionId PartitionId to persist.
-     * @return The ConsumerState that was persisted via persistSidelineRequestState().
+     * @param consumerPartition consumer partition.
+     * @return Payload of the sideline data that was persisted.
      */
-    SidelinePayload retrieveSidelineRequest(final SidelineRequestIdentifier id, int partitionId);
+    SidelinePayload retrieveSidelineRequest(final SidelineRequestIdentifier id, final ConsumerPartition consumerPartition);
 
     /**
      * List the partitions for the given sideline request.
      * @param id Identifier for the sideline request that you want the partitions for
-     * @return A list of the partitions for the sideline request
+     * @return A list of the consumer partitions for the sideline request
      */
-    Set<Integer> listSidelineRequestPartitions(final SidelineRequestIdentifier id);
+    Set<ConsumerPartition> listSidelineRequestPartitions(final SidelineRequestIdentifier id);
 
     /**
      * Removes a sideline request from the persistence layer.
-     * @param id - SidelineRequestIdentifier you want to clear.
-     * @param partitionId - Partition of the sideline request you want to clear
+     * @param id Identifier to clear.
+     * @param consumerPartition consumer partition.
      */
-    void clearSidelineRequest(SidelineRequestIdentifier id, int partitionId);
+    void clearSidelineRequest(final SidelineRequestIdentifier id, final ConsumerPartition consumerPartition);
 
     /**
      * Lists existing sideline requests.

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -45,7 +45,6 @@ import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -147,7 +146,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         data.put("filterChainStep", Serializer.serialize(request.step));
 
         // Persist!
-        curatorHelper.writeJson(getZkRequestStatePathForPartition(id.toString(), consumerPartition.partition()), data);
+        curatorHelper.writeJson(getZkRequestStatePathForConsumerPartition(id.toString(), consumerPartition), data);
     }
 
     @Override
@@ -158,7 +157,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         Preconditions.checkNotNull(id, "SidelineRequestIdentifier is required.");
 
         // Read!
-        final String path = getZkRequestStatePathForPartition(id.toString(), consumerPartition.partition());
+        final String path = getZkRequestStatePathForConsumerPartition(id.toString(), consumerPartition);
         // TODO: We should make a real object for this and update readJson() to support a class declaration
         Map<Object, Object> json = curatorHelper.readJson(path);
         logger.debug("Read request state from Zookeeper at {}: {}", path, json);
@@ -193,7 +192,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
         Preconditions.checkNotNull(id, "SidelineRequestIdentifier is required.");
 
         // Delete!
-        final String path = getZkRequestStatePathForPartition(id.toString(), consumerPartition.partition());
+        final String path = getZkRequestStatePathForConsumerPartition(id.toString(), consumerPartition);
         logger.info("Delete request from Zookeeper at {}", path);
         curatorHelper.deleteNode(path);
 
@@ -282,8 +281,8 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
     /**
      * @return full zookeeper path for our sideline request for a specific partition.
      */
-    String getZkRequestStatePathForPartition(final String sidelineIdentifierStr, final int partitionId) {
-        return getZkRequestStatePath(sidelineIdentifierStr) + "/" + partitionId;
+    String getZkRequestStatePathForConsumerPartition(final String sidelineIdentifierStr, final ConsumerPartition consumerPartition) {
+        return getZkRequestStatePath(sidelineIdentifierStr) + "/" + consumerPartition.namespace() + "/" + consumerPartition.partition();
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.storm.spout.sideline.handler;
 
+import com.salesforce.storm.spout.dynamic.ConsumerPartition;
 import com.salesforce.storm.spout.dynamic.DynamicSpout;
 import com.salesforce.storm.spout.sideline.SidelineVirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.VirtualSpout;
@@ -119,6 +120,8 @@ public class SidelineSpoutHandlerTest {
     public void testOnSpoutOpenResumesSidelines() {
         final Map<String, Object> config = getConfig();
 
+        final String namespace = "Test";
+
         final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
         final StaticMessageFilter startFilter = new StaticMessageFilter();
         final SidelineRequest startRequest = new SidelineRequest(startRequestId, startFilter);
@@ -144,7 +147,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.START,
             startRequestId,
             startRequest,
-            0,
+            new ConsumerPartition(namespace, 0),
             1L,
             2L
         );
@@ -153,7 +156,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.STOP,
             stopRequestId,
             stopRequest,
-            1,
+            new ConsumerPartition(namespace, 1),
             3L,
             4L
         );
@@ -193,6 +196,8 @@ public class SidelineSpoutHandlerTest {
     public void testStartSidelining() {
         final Map<String, Object> config = getConfig();
 
+        final String namespace = "Test";
+
         final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
         final StaticMessageFilter startFilter = new StaticMessageFilter();
         final SidelineRequest startRequest = new SidelineRequest(startRequestId, startFilter);
@@ -229,7 +234,7 @@ public class SidelineSpoutHandlerTest {
             sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().get(startRequestId)
         );
 
-        final SidelinePayload partition0 = persistenceAdapter.retrieveSidelineRequest(startRequestId, 0);
+        final SidelinePayload partition0 = persistenceAdapter.retrieveSidelineRequest(startRequestId, new ConsumerPartition(namespace, 0));
 
         assertEquals(SidelineType.START, partition0.type);
         assertEquals(startRequestId, partition0.id);
@@ -237,7 +242,7 @@ public class SidelineSpoutHandlerTest {
         assertEquals(Long.valueOf(1L), partition0.startingOffset);
         assertNull(partition0.endingOffset);
 
-        final SidelinePayload partition5 = persistenceAdapter.retrieveSidelineRequest(startRequestId, 5);
+        final SidelinePayload partition5 = persistenceAdapter.retrieveSidelineRequest(startRequestId, new ConsumerPartition(namespace, 5));
 
         assertEquals(SidelineType.START, partition5.type);
         assertEquals(startRequestId, partition5.id);
@@ -257,6 +262,8 @@ public class SidelineSpoutHandlerTest {
     @Test
     public void testStopSidelining() {
         final Map<String, Object> config = getConfig();
+
+        final String namespace = "Test";
 
         final SidelineRequestIdentifier stopRequestId = new SidelineRequestIdentifier("StopRequest");
         final StaticMessageFilter stopFilter = new StaticMessageFilter();
@@ -278,7 +285,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.START,
             stopRequestId,
             stopRequest,
-            0, // partition
+            new ConsumerPartition(namespace, 0),
             1L, // starting offset
             null // ending offset
         );
@@ -286,7 +293,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.START,
             stopRequestId,
             stopRequest,
-            5, // partition
+            new ConsumerPartition(namespace, 5),
             3L, // starting offset
             null // ending offset
         );
@@ -311,7 +318,7 @@ public class SidelineSpoutHandlerTest {
             sidelineSpoutHandler.getFireHoseSpout().getFilterChain().getSteps().size()
         );
 
-        final SidelinePayload partition0 = persistenceAdapter.retrieveSidelineRequest(stopRequestId, 0);
+        final SidelinePayload partition0 = persistenceAdapter.retrieveSidelineRequest(stopRequestId, new ConsumerPartition(namespace, 0));
 
         assertEquals(SidelineType.STOP, partition0.type);
         assertEquals(stopRequestId, partition0.id);
@@ -319,7 +326,7 @@ public class SidelineSpoutHandlerTest {
         assertEquals(Long.valueOf(1L), partition0.startingOffset);
         assertEquals(Long.valueOf(1L), partition0.endingOffset);
 
-        final SidelinePayload partition5 = persistenceAdapter.retrieveSidelineRequest(stopRequestId, 5);
+        final SidelinePayload partition5 = persistenceAdapter.retrieveSidelineRequest(stopRequestId, new ConsumerPartition(namespace, 5));
 
         assertEquals(SidelineType.STOP, partition5.type);
         assertEquals(stopRequestId, partition5.id);
@@ -433,6 +440,8 @@ public class SidelineSpoutHandlerTest {
     public void testLoadSidelines() {
         final Map<String, Object> config = getConfig();
 
+        final String namespace = "Test";
+
         final DynamicSpout spout = new DynamicSpout(config);
         spout.open(null, new MockTopologyContext(), null);
 
@@ -465,7 +474,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.START,
             startRequestId,
             startRequest,
-            0,
+            new ConsumerPartition(namespace, 0),
             1L,
             2L
         );
@@ -474,7 +483,7 @@ public class SidelineSpoutHandlerTest {
             SidelineType.STOP,
             stopRequestId,
             stopRequest,
-            1,
+            new ConsumerPartition(namespace, 1),
             3L,
             4L
         );

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -196,7 +196,7 @@ public class SidelineSpoutHandlerTest {
     public void testStartSidelining() {
         final Map<String, Object> config = getConfig();
 
-        final String namespace = "Test";
+        final String namespace = MockConsumer.topic;
 
         final SidelineRequestIdentifier startRequestId = new SidelineRequestIdentifier("StartRequest");
         final StaticMessageFilter startFilter = new StaticMessageFilter();
@@ -263,7 +263,7 @@ public class SidelineSpoutHandlerTest {
     public void testStopSidelining() {
         final Map<String, Object> config = getConfig();
 
-        final String namespace = "Test";
+        final String namespace = MockConsumer.topic;
 
         final SidelineRequestIdentifier stopRequestId = new SidelineRequestIdentifier("StopRequest");
         final StaticMessageFilter stopFilter = new StaticMessageFilter();

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
@@ -26,6 +26,7 @@
 package com.salesforce.storm.spout.sideline.handler;
 
 import com.google.common.collect.Maps;
+import com.salesforce.storm.spout.dynamic.ConsumerPartition;
 import com.salesforce.storm.spout.sideline.SidelineVirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.consumer.MockConsumer;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
@@ -54,6 +55,7 @@ public class SidelineVirtualSpoutHandlerTest {
     @Test
     public void testOnVirtualSpoutCompletion() {
         final String prefix = "MyVirtualSpout";
+        final String namespace = "Test";
         final SidelineRequestIdentifier sidelineRequestIdentifier = new SidelineRequestIdentifier("SidelineRequest");
         final SidelineRequest sidelineRequest = new SidelineRequest(sidelineRequestIdentifier, new StaticMessageFilter());
 
@@ -77,7 +79,7 @@ public class SidelineVirtualSpoutHandlerTest {
             SidelineType.STOP,
             sidelineRequestIdentifier,
             sidelineRequest,
-            0, // partition
+            new ConsumerPartition(namespace, 0), // partition
             1L, // starting offset
             1L // ending offset
         );
@@ -85,7 +87,7 @@ public class SidelineVirtualSpoutHandlerTest {
             SidelineType.START,
             sidelineRequestIdentifier,
             sidelineRequest,
-            5, // partition
+            new ConsumerPartition(namespace, 5), // partition
             3L, // starting offset
             2L // ending offset
         );
@@ -95,13 +97,13 @@ public class SidelineVirtualSpoutHandlerTest {
 
         // Do we still have a record for partition 0?
         SidelinePayload partition0 = sidelineVirtualSpoutHandler.getPersistenceAdapter()
-            .retrieveSidelineRequest(sidelineRequestIdentifier, 0);
+            .retrieveSidelineRequest(sidelineRequestIdentifier, new ConsumerPartition(namespace, 0));
 
         assertNull(partition0);
 
         // Do we still have a record for partition 5?
         SidelinePayload partition5 = sidelineVirtualSpoutHandler.getPersistenceAdapter()
-            .retrieveSidelineRequest(sidelineRequestIdentifier, 5);
+            .retrieveSidelineRequest(sidelineRequestIdentifier, new ConsumerPartition(namespace, 5));
 
         assertNull(partition5);
 

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
@@ -55,7 +55,7 @@ public class SidelineVirtualSpoutHandlerTest {
     @Test
     public void testOnVirtualSpoutCompletion() {
         final String prefix = "MyVirtualSpout";
-        final String namespace = "Test";
+        final String namespace = MockConsumer.topic;
         final SidelineRequestIdentifier sidelineRequestIdentifier = new SidelineRequestIdentifier("SidelineRequest");
         final SidelineRequest sidelineRequest = new SidelineRequest(sidelineRequestIdentifier, new StaticMessageFilter());
 

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -115,7 +115,8 @@ public class ZookeeperPersistenceAdapterTest {
         final String configuredZkRoot = getRandomZkRootNode();
         final String expectedZkRoot = configuredZkRoot + "/" + configuredConsumerPrefix;
         final String expectedConsumerId = configuredConsumerPrefix + ":MyConsumerId";
-        final String expectedZkRequestStatePath = expectedZkRoot + "/requests/" + expectedConsumerId + "/" + String.valueOf(partitionId);
+        final String expectedZkRequestStatePath = expectedZkRoot + "/requests/" + expectedConsumerId + "/" + namespace + "/"
+            + String.valueOf(partitionId);
 
         // Create our config
         final Map topologyConfig = createDefaultConfig(getZkServer().getConnectString(), configuredZkRoot, configuredConsumerPrefix);
@@ -366,7 +367,7 @@ public class ZookeeperPersistenceAdapterTest {
 
         // 5. Grab the value and validate it
         final byte[] storedDataBytes = zookeeperClient.getData(
-            zkRequestsRootNodePath + "/" + sidelineRequestIdentifier.toString() + "/" + 0,
+            zkRequestsRootNodePath + "/" + sidelineRequestIdentifier.toString() + "/" + topicName + "/" + 0,
             false,
             null
         );
@@ -384,7 +385,7 @@ public class ZookeeperPersistenceAdapterTest {
 
         // Validate in the Zk Client.
         doesNodeExist = zookeeperClient.exists(
-            zkRequestsRootNodePath + "/" + sidelineRequestIdentifier.toString() + "/" + 0,
+            zkRequestsRootNodePath + "/" + sidelineRequestIdentifier.toString() + "/" + topicName + "/" + 0,
             false
         );
 
@@ -593,11 +594,17 @@ public class ZookeeperPersistenceAdapterTest {
 
         Set<ConsumerPartition> partitionsForSidelineRequest1 = persistenceAdapter.listSidelineRequestPartitions(sidelineRequestIdentifier1);
 
-        assertEquals(Collections.unmodifiableSet(Sets.newHashSet(0, 1)), partitionsForSidelineRequest1);
+        assertEquals(
+            Sets.newHashSet(new ConsumerPartition(topicName, 0), new ConsumerPartition(topicName, 1)),
+            partitionsForSidelineRequest1
+        );
 
         Set<ConsumerPartition> partitionsForSidelineRequest2 = persistenceAdapter.listSidelineRequestPartitions(sidelineRequestIdentifier2);
 
-        assertEquals(Collections.unmodifiableSet(Sets.newHashSet(0)), partitionsForSidelineRequest2);
+        assertEquals(
+            Sets.newHashSet(new ConsumerPartition(topicName, 0)),
+            partitionsForSidelineRequest2
+        );
 
         // Close adapter
         persistenceAdapter.close();

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -128,7 +128,7 @@ public class ZookeeperPersistenceAdapterTest {
 
         assertEquals(
             "Unexpected zkRequestStatePath returned",
-            expectedZkRequestStatePath, persistenceAdapter.getZkRequestStatePathForPartition(expectedConsumerId, partitionId)
+            expectedZkRequestStatePath, persistenceAdapter.getZkRequestStatePathForConsumerPartition(expectedConsumerId, partitionId)
         );
 
         // Close everyone out

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -109,6 +109,7 @@ public class ZookeeperPersistenceAdapterTest {
      */
     @Test
     public void testOpen() {
+        final String namespace = "Test";
         final int partitionId = 1;
         final String configuredConsumerPrefix = "consumerIdPrefix";
         final String configuredZkRoot = getRandomZkRootNode();
@@ -128,7 +129,8 @@ public class ZookeeperPersistenceAdapterTest {
 
         assertEquals(
             "Unexpected zkRequestStatePath returned",
-            expectedZkRequestStatePath, persistenceAdapter.getZkRequestStatePathForConsumerPartition(expectedConsumerId, partitionId)
+            expectedZkRequestStatePath,
+            persistenceAdapter.getZkRequestStatePathForConsumerPartition(expectedConsumerId, new ConsumerPartition(namespace, partitionId))
         );
 
         // Close everyone out


### PR DESCRIPTION
The goal here is to not have to call out to the kafka config for the topic by relying on `ConsumerPartition` directly. Long term we could actually use `ConsumerState` wholesale here and let the specific persistence adapter loop over the partitions - if they need to.

Addresses comment #46