### PR TITLE
Add support for resume state in sidelining

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DelegateSpout.java
@@ -93,9 +93,9 @@ public interface DelegateSpout {
     ConsumerState getEndingState();
 
     /**
-     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     * Set the ending state of the {@link DelegateSpout}.for when it should finish consuming.
      *
-     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should finish consuming.
      */
     void setEndingState(ConsumerState endingState);
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -445,6 +445,20 @@ public class DynamicSpout extends BaseRichSpout {
     }
 
     /**
+     * Get a {@link DelegateSpout} instance from the {@link SpoutCoordinator}.
+     *
+     * This is useful is you want to manipulate the filter chain or alter the ending state after a {@link DelegateSpout} has
+     * been added to the {@link SpoutCoordinator}.
+     *
+     * @param virtualSpoutIdentifier identifier for teh {@link DelegateSpout} instance to get from the {@link SpoutCoordinator}.
+     * @return {@link DelegateSpout} instance
+     */
+    public DelegateSpout getVirtualSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
+        checkSpoutOpened();
+        return getSpoutCoordinator().getVirtualSpout(virtualSpoutIdentifier);
+    }
+
+    /**
      * Get the total number of virtual spouts in the coordinator.
      *
      * This method crosses the thread barrier to determine its value.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -453,7 +453,7 @@ public class DynamicSpout extends BaseRichSpout {
      * @param virtualSpoutIdentifier identifier for teh {@link DelegateSpout} instance to get from the {@link SpoutCoordinator}.
      * @return {@link DelegateSpout} instance
      */
-    public DelegateSpout getVirtualSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
+    public DelegateSpout getVirtualSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) throws SpoutDoesNotExistException {
         checkSpoutOpened();
         return getSpoutCoordinator().getVirtualSpout(virtualSpoutIdentifier);
     }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -486,9 +486,9 @@ public class VirtualSpout implements DelegateSpout {
     }
 
     /**
-     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     * Set the ending state of the {@link DelegateSpout} for when it should finish consuming.
      *
-     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should finish consuming.
      */
     @Override
     public void setEndingState(final ConsumerState endingState) {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -218,6 +218,13 @@ public class SpoutCoordinator implements Runnable {
      * @return {@link DelegateSpout} instance
      */
     public synchronized DelegateSpout getVirtualSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
+        if (!hasVirtualSpout(virtualSpoutIdentifier)) {
+            throw new SpoutDoesNotExistException(
+                "VirtualSpout " + virtualSpoutIdentifier + " does not exist in the SpoutCoordinator.",
+                virtualSpoutIdentifier
+            );
+        }
+
         return runningSpouts.get(virtualSpoutIdentifier).getSpoutRunner().getSpout();
     }
 

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -209,6 +209,19 @@ public class SpoutCoordinator implements Runnable {
     }
 
     /**
+     * Get a {@link DelegateSpout} instance from the {@link SpoutCoordinator}.
+     *
+     * This is useful is you want to manipulate the filter chain or alter the ending state after a {@link DelegateSpout} has
+     * been added to the {@link SpoutCoordinator}.
+     *
+     * @param virtualSpoutIdentifier identifier for teh {@link DelegateSpout} instance to get from the {@link SpoutCoordinator}.
+     * @return {@link DelegateSpout} instance
+     */
+    public synchronized DelegateSpout getVirtualSpout(final VirtualSpoutIdentifier virtualSpoutIdentifier) {
+        return runningSpouts.get(virtualSpoutIdentifier).getSpoutRunner().getSpout();
+    }
+
+    /**
      * Signals to a VirtualSpout to stop, ultimately removing it from the monitor.
      * This call will block waiting for the VirtualSpout instance to shutdown.
      *

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -351,7 +351,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      */
     @Override
     public void start(SidelineRequest sidelineRequest) {
-        logger.info("Received START sideline request");
+        logger.info("Received START sideline request {}", sidelineRequest.id);
 
         // Store the offset that this request was made at, when the sideline stops we will begin processing at
         // this offset
@@ -396,6 +396,8 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      */
     @Override
     public void resume(SidelineRequest sidelineRequest) {
+        logger.info("Received RESUME sideline request {}", sidelineRequest.id);
+
         final SidelineRequestIdentifier id = sidelineRequest.id;
 
         // Get the step that was applied to the firehose
@@ -480,9 +482,9 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      */
     @Override
     public void resolve(SidelineRequest sidelineRequest) {
-        final SidelineRequestIdentifier id = sidelineRequest.id;
+        logger.info("Received RESOLVE sideline request {}", sidelineRequest.id);
 
-        logger.info("Received FINISH sideline request");
+        final SidelineRequestIdentifier id = sidelineRequest.id;
 
         // Remove the steps associated with this sideline request
         fireHoseSpout.getFilterChain().removeStep(id);

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -35,7 +35,6 @@ import com.salesforce.storm.spout.dynamic.DynamicSpout;
 import com.salesforce.storm.spout.dynamic.FactoryManager;
 import com.salesforce.storm.spout.dynamic.handler.SpoutHandler;
 import com.salesforce.storm.spout.sideline.SidelineVirtualSpoutIdentifier;
-import com.salesforce.storm.spout.dynamic.VirtualSpout;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
@@ -83,11 +82,6 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      * The Spout configuration map.
      */
     private Map<String, Object> spoutConfig;
-
-    /**
-     * The Topology Context object.
-     */
-    private TopologyContext topologyContext;
 
     /**
      * Timer for periodically checking the state of the VirtualSpouts being managed.
@@ -186,7 +180,6 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
         final TopologyContext topologyContext
     ) {
         this.spout = spout;
-        this.topologyContext = topologyContext;
 
         createSidelineTriggers();
 
@@ -268,7 +261,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
 
                 startingStateBuilder.withPartition(partition, payload.startingOffset);
 
-                // We only have an ending offset on STOP requests
+                // We do not necessarily have an ending offset, it all depends where we are at in the sideline lifecycle
                 if (payload.endingOffset != null) {
                     endingStateStateBuilder.withPartition(partition, payload.endingOffset);
                 }
@@ -285,9 +278,9 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
                 continue;
             }
 
-            // Resuming a start request means we apply the previous filter chain to the fire hose
-            if (payload.type.equals(SidelineType.START)) {
-                logger.info("Resuming START sideline {} {}", payload.id, payload.request.step);
+            // Loading a request in these states means we apply the previous filter chain to the fire hose
+            if (payload.type.equals(SidelineType.START) || payload.type.equals(SidelineType.RESUME)) {
+                logger.info("Handling {} request for sideline {} {}", payload.type, payload.id, payload.request.step);
 
                 // Only add the step if the id isn't already in the chain.  Note that we do NOT check for the step here, it's possible
                 // though very unusual to have the exact same step used in different requests. While that's silly, we don't want to choke
@@ -300,8 +293,10 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
                 }
             }
 
-            // Resuming a stopped request means we spin up a new sideline spout
-            if (payload.type.equals(SidelineType.STOP)) {
+            // Loading a request in these states means we spin up a new sideline spout
+            if (payload.type.equals(SidelineType.RESUME) || payload.type.equals(SidelineType.RESOLVE)) {
+                logger.info("Handling {} request for sideline {} {}", payload.type, payload.id, payload.request.step);
+
                 // This method will check to see that the VirtualSpout isn't already in the SpoutCoordinator before adding it
                 addSidelineVirtualSpout(
                     payload.id,
@@ -344,15 +339,18 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
      * @param sidelineRequest sideline request.
      * @return true it does, false it does not.
      */
-    public boolean isSidelineStarted(SidelineRequest sidelineRequest) {
+    @Override
+    public boolean isStarted(SidelineRequest sidelineRequest) {
         return fireHoseSpout.getFilterChain().hasStep(sidelineRequest.id);
     }
 
     /**
-     * Starts a sideline request.
-     * @param sidelineRequest representation of the request that is being started.
+     * Start processing on the firehose for a future sideline.
+     *
+     * @param sidelineRequest sideline request.
      */
-    public void startSidelining(SidelineRequest sidelineRequest) {
+    @Override
+    public void start(SidelineRequest sidelineRequest) {
         logger.info("Received START sideline request");
 
         // Store the offset that this request was made at, when the sideline stops we will begin processing at
@@ -379,49 +377,38 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
     }
 
     /**
-     * Does a sideline exist in the stopped state?
+     * To be in the resumed state, does the {@link SidelineRequest} have a {@link com.salesforce.storm.spout.dynamic.VirtualSpout}
+     * for it's window and a {@link FilterChainStep} on the firehose?
+
      * @param sidelineRequest sideline request.
      * @return true it has, false it has not.
      */
-    public boolean isSidelineStopped(SidelineRequest sidelineRequest) {
+    @Override
+    public boolean isResumed(SidelineRequest sidelineRequest) {
         return spout.hasVirtualSpout(
             generateSidelineVirtualSpoutId(sidelineRequest.id)
-        );
+        ) && fireHoseSpout.getFilterChain().hasStep(sidelineRequest.id);
     }
 
     /**
-     * Stops a sideline request.
-     * @param sidelineRequest A representation of the request that is being stopped
+     * Resumes processing of messages that were sidelined.
+     * @param sidelineRequest sideline request.
      */
-    public void stopSidelining(SidelineRequest sidelineRequest) {
-        final SidelineRequestIdentifier id = (SidelineRequestIdentifier) fireHoseSpout.getFilterChain().findStep(sidelineRequest.step);
+    @Override
+    public void resume(SidelineRequest sidelineRequest) {
+        final SidelineRequestIdentifier id = sidelineRequest.id;
 
-        if (id == null) {
-            logger.error(
-                "Received STOP sideline request, but I don't actually have any filter chain steps for it! Make sure "
-                + "you check that your filter implements an equals() method. {} {}",
-                sidelineRequest.step,
-                fireHoseSpout.getFilterChain().getSteps()
-            );
-            return;
-        }
+        // Get the step that was applied to the firehose
+        final FilterChainStep step = fireHoseSpout.getFilterChain().getStep(id);
 
-        logger.info("Received STOP sideline request");
-
-        // Remove the steps associated with this sideline request
-        final FilterChainStep step = fireHoseSpout.getFilterChain().removeStep(id);
         // Create a negated version of the step we just pulled from the firehose
         final FilterChainStep negatedStep = new NegatingFilterChainStep(step);
-
-        // This is the state that the VirtualSpout should end with
-        final ConsumerState endingState = getFireHoseCurrentState();
 
         // We'll construct a consumer state from the various partition data stored for this sideline request
         final ConsumerState.ConsumerStateBuilder startingStateBuilder = ConsumerState.builder();
 
-        // We are looping over the current partitions for the firehose, functionally this is the collection of partitions
-        // assigned to this particular sideline spout instance
-        for (final ConsumerPartition consumerPartition : endingState.getConsumerPartitions()) {
+        // We are looping over the current partitions for the firehose
+        for (final ConsumerPartition consumerPartition : fireHoseSpout.getCurrentState().getConsumerPartitions()) {
             // This is the state that the VirtualSpout should start with
             final SidelinePayload sidelinePayload = retrieveSidelinePayload(
                 id,
@@ -450,12 +437,12 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
 
             // Persist the side line request state with the new negated version of the steps.
             getPersistenceAdapter().persistSidelineRequestState(
-                SidelineType.STOP,
+                SidelineType.RESOLVE,
                 id,
                 new SidelineRequest(id, negatedStep), // Persist the negated steps, so they load properly on resume
                 consumerPartition,
                 sidelinePayload.startingOffset,
-                endingState.getOffsetForNamespaceAndPartition(consumerPartition)
+                null
             );
         }
 
@@ -466,11 +453,81 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
             id,
             negatedStep,
             startingState,
-            endingState
+            null
         );
 
         // Update stop countBy metric
-        spout.getMetricsRecorder().count(SidelineMetrics.STOP);
+        spout.getMetricsRecorder().count(SidelineMetrics.RESUME);
+    }
+
+    /**
+     * To be in the completing state, does the {@link SidelineRequest} have a {@link com.salesforce.storm.spout.dynamic.VirtualSpout}
+     * for it's window and a {@link FilterChainStep} absent from the firehose?
+     *
+     * @param sidelineRequest sideline request.
+     * @return true it has, false it has not.
+     */
+    @Override
+    public boolean isResolving(SidelineRequest sidelineRequest) {
+        return spout.hasVirtualSpout(
+            generateSidelineVirtualSpoutId(sidelineRequest.id)
+        ) &&  !fireHoseSpout.getFilterChain().hasStep(sidelineRequest.id);
+    }
+
+    /**
+     * Completes processing of messages that have been resumed.
+     * @param sidelineRequest sideline request.
+     */
+    @Override
+    public void resolve(SidelineRequest sidelineRequest) {
+        final SidelineRequestIdentifier id = sidelineRequest.id;
+
+        logger.info("Received FINISH sideline request");
+
+        // Remove the steps associated with this sideline request
+        fireHoseSpout.getFilterChain().removeStep(id);
+
+        final ConsumerState endingState = fireHoseSpout.getCurrentState();
+
+        // Identifier based off of the id of the sideline request
+        final VirtualSpoutIdentifier virtualSpoutIdentifier = generateSidelineVirtualSpoutId(id);
+
+        // If we can't find this VirtualSpout we should bail and not proceed any further.
+        if (!spout.hasVirtualSpout(virtualSpoutIdentifier)) {
+            logger.error("SidelineRequest to resolve {} was made, but the correspond VirtualSpout does not exist.", sidelineRequest.id);
+            return;
+        }
+
+        // Once the filter chain has been removed from the firehose, mark our sideline with an ending offset
+        spout.getVirtualSpout(generateSidelineVirtualSpoutId(id)).setEndingState(endingState);
+
+        // We are looping over the current partitions for the firehose
+        for (final ConsumerPartition consumerPartition : endingState.getConsumerPartitions()) {
+            // This is the state that the VirtualSpout should start with
+            final SidelinePayload sidelinePayload = retrieveSidelinePayload(
+                id,
+                consumerPartition
+            );
+
+            if (sidelinePayload == null) {
+                logger.warn("Sideline {} on partition {} payload was null, this is probably a serialization problem.");
+                continue;
+            }
+
+            logger.info("Loaded sideline payload for {} = {}", consumerPartition, sidelinePayload);
+
+            // Update the sideline request with our ending offset
+            getPersistenceAdapter().persistSidelineRequestState(
+                SidelineType.RESOLVE,
+                id,
+                sidelinePayload.request,
+                consumerPartition,
+                sidelinePayload.startingOffset,
+                endingState.getOffsetForNamespaceAndPartition(consumerPartition)
+            );
+        }
+
+        spout.getMetricsRecorder().count(SidelineMetrics.RESOLVE);
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -437,7 +437,7 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
 
             // Persist the side line request state with the new negated version of the steps.
             getPersistenceAdapter().persistSidelineRequestState(
-                SidelineType.RESOLVE,
+                SidelineType.RESUME,
                 id,
                 new SidelineRequest(id, negatedStep), // Persist the negated steps, so they load properly on resume
                 consumerPartition,

--- a/src/main/java/com/salesforce/storm/spout/sideline/metrics/SidelineMetrics.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/metrics/SidelineMetrics.java
@@ -47,7 +47,15 @@ public final class SidelineMetrics {
         type = MetricDocumentation.Type.COUNTER,
         unit = MetricDocumentation.Unit.NUMBER,
         category = MetricDocumentation.Category.SIDELINE,
-        description = "Total number of stopped sidelines."
+        description = "Total number of resumed sidelines."
     )
-    public static final MetricDefinition STOP = new ClassMetric(SidelineSpoutHandler.class, "stop");
+    public static final MetricDefinition RESUME = new ClassMetric(SidelineSpoutHandler.class, "resume");
+
+    @MetricDocumentation(
+        type = MetricDocumentation.Type.COUNTER,
+        unit = MetricDocumentation.Unit.NUMBER,
+        category = MetricDocumentation.Category.SIDELINE,
+        description = "Total number of resolving sidelines."
+    )
+    public static final MetricDefinition RESOLVE = new ClassMetric(SidelineSpoutHandler.class, "resolve");
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
@@ -30,7 +30,21 @@ package com.salesforce.storm.spout.sideline.trigger;
  */
 public enum SidelineType {
 
+    /**
+     * Start means that a filter is being applied to the firehose and the current offset is captured so it can be used later
+     * during the resume phase.
+     */
     START,
+    /**
+     * Resume means that a filter is on the firehose, and a new {@link com.salesforce.storm.spout.dynamic.VirtualSpout} is being
+     * spun up with the negation of that filter. In other words, whatever that filter was filtering will now be processed
+     * in it's own thread where it can be throttled independently of the firehose.
+     */
     RESUME,
+    /**
+     * Resolve means that an ending offset is being applied to the {@link com.salesforce.storm.spout.dynamic.VirtualSpout} and it
+     * cease to run whenever it reached that {@link com.salesforce.storm.spout.dynamic.consumer.ConsumerState}. The filter is also
+     * removed from the firehose, so that future record's are processed in real time.
+     */
     RESOLVE,
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
@@ -31,5 +31,6 @@ package com.salesforce.storm.spout.sideline.trigger;
 public enum SidelineType {
 
     START,
-    STOP,
+    RESUME,
+    RESOLVE,
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
@@ -53,8 +53,8 @@ public class TriggerEvent {
     private LocalDateTime updatedAt;
 
     /**
-     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of sideline state
-     * for the system.
+     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of
+     * sideline state for the system.
      *
      * When you create a TriggerEvent in Zookeeper always set processed = false, the trigger implementation will flip this to true
      * after it has been picked up and handled by the trigger. This allows you to distinguish an event that's been handled by the

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
@@ -33,8 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates whether or not a START or STOP
- * request should be processed.
+ * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of sideline state
+ * for the system.
  */
 public class TriggerEvent {
 
@@ -53,15 +53,15 @@ public class TriggerEvent {
     private LocalDateTime updatedAt;
 
     /**
-     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates whether or not a START or STOP
-     * request should be processed.
+     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of sideline state
+     * for the system.
      *
      * When you create a TriggerEvent in Zookeeper always set processed = false, the trigger implementation will flip this to true
      * after it has been picked up and handled by the trigger. This allows you to distinguish an event that's been handled by the
      * trigger and one that has not.
      *
-     * @param type sideline type, either start of stop.
-     * @param data data bag, maps keys to values.
+     * @param type sideline type.
+     * @param data data bag, key => values.
      * @param createdAt when the event was created.
      * @param createdBy who created the event.
      * @param description a description of the reason for the sideline request.

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
@@ -229,7 +229,7 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
     }
 
     /**
-     * Using a trigger event process a START/STOP sideline request.
+     * Using a trigger event process a sideline request.
      * @param triggerEvent trigger event.
      */
     private void handleSidelining(final String path, final TriggerEvent triggerEvent) {
@@ -257,12 +257,17 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
 
         if (triggerEvent.getType().equals(SidelineType.START)) {
             logger.info("Starting sideline request {} from event {}", sidelineRequest, triggerEvent);
-            sidelineController.startSidelining(sidelineRequest);
+            sidelineController.start(sidelineRequest);
         }
 
-        if (triggerEvent.getType().equals(SidelineType.STOP)) {
+        if (triggerEvent.getType().equals(SidelineType.RESUME)) {
+            logger.info("Starting sideline request {} from event {}", sidelineRequest, triggerEvent);
+            sidelineController.resume(sidelineRequest);
+        }
+
+        if (triggerEvent.getType().equals(SidelineType.RESOLVE)) {
             logger.info("Stopping sideline request {} from event {}", sidelineRequest, triggerEvent);
-            sidelineController.stopSidelining(sidelineRequest);
+            sidelineController.resolve(sidelineRequest);
         }
 
         // Write the trigger event back to its path and flip the processed bit to true
@@ -272,7 +277,7 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
             triggerEvent.getCreatedAt(),
             triggerEvent.getCreatedBy(),
             triggerEvent.getDescription(),
-            // Explicit set this as processed
+            // Explicitly set this as processed
             true,
             // Update the updated at date to right now
             LocalDateTime.now()

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockDelegateSpout.java
@@ -117,9 +117,9 @@ public class MockDelegateSpout implements DelegateSpout {
     }
 
     /**
-     * Set the ending state of the {@link DelegateSpout}.for when it should be marked as complete.
+     * Set the ending state of the {@link DelegateSpout} for when it should finish consuming.
      *
-     * @param endingState ending consumer state for when the {@link DelegateSpout} should be marked as complete.
+     * @param endingState ending consumer state for when the {@link DelegateSpout} should finish consuming.
      */
     @Override
     public void setEndingState(final ConsumerState endingState) {

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -66,8 +66,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Iterator;
@@ -186,8 +184,11 @@ public class SidelineSpoutTest {
         // all tuples are filtered.
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 10, 3000L);
 
+        // TODO: Validate something in here
+        StaticTrigger.sendResumeRequest(request);
+
         // Send a stop sideline request
-        StaticTrigger.sendStopRequest(request);
+        StaticTrigger.sendCompleteRequest(request);
 
         // Wait for the sideline vspout to start,
         waitForVirtualSpouts(spout, 2);
@@ -293,8 +294,6 @@ public class SidelineSpoutTest {
         // This means that our starting offset for the sideline'd data should start at offset 3 (we acked offsets 0, 1, 2)
         StaticTrigger.sendStartRequest(request);
 
-        final SidelineRequestIdentifier sidelineRequestIdentifier = request.id;
-
         // Produce 5 more messages into kafka, should be offsets [10,11,12,13,14]
         final List<ProducedKafkaRecord<byte[], byte[]>> additionalProducedRecords = produceRecords(5, 0);
 
@@ -335,8 +334,11 @@ public class SidelineSpoutTest {
         // offsets [4,5,6,7,8,9,10,11,12,13,14] <- last committed offset now 14 on firehose.
         validateNextTupleEmitsNothing(spout, spoutOutputCollector, 20, 100L);
 
+        // TODO: Validate something in here
+        StaticTrigger.sendResumeRequest(request);
+
         // Send a stop sideline request
-        StaticTrigger.sendStopRequest(request);
+        StaticTrigger.sendCompleteRequest(request);
         final SidelineVirtualSpoutIdentifier sidelineIdentifier = new SidelineVirtualSpoutIdentifier(consumerIdPrefix, request.id);
 
         // Verify 2 VirtualSpouts are running

--- a/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/SidelineSpoutTest.java
@@ -188,7 +188,7 @@ public class SidelineSpoutTest {
         StaticTrigger.sendResumeRequest(request);
 
         // Send a stop sideline request
-        StaticTrigger.sendCompleteRequest(request);
+        StaticTrigger.sendResolveRequest(request);
 
         // Wait for the sideline vspout to start,
         waitForVirtualSpouts(spout, 2);
@@ -338,7 +338,7 @@ public class SidelineSpoutTest {
         StaticTrigger.sendResumeRequest(request);
 
         // Send a stop sideline request
-        StaticTrigger.sendCompleteRequest(request);
+        StaticTrigger.sendResolveRequest(request);
         final SidelineVirtualSpoutIdentifier sidelineIdentifier = new SidelineVirtualSpoutIdentifier(consumerIdPrefix, request.id);
 
         // Verify 2 VirtualSpouts are running

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineVirtualSpoutHandlerTest.java
@@ -76,7 +76,7 @@ public class SidelineVirtualSpoutHandlerTest {
 
         // Persist some stopping requests that we cleanup upon completion
         sidelineVirtualSpoutHandler.getPersistenceAdapter().persistSidelineRequestState(
-            SidelineType.STOP,
+            SidelineType.RESOLVE,
             sidelineRequestIdentifier,
             sidelineRequest,
             new ConsumerPartition(namespace, 0), // partition

--- a/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapterTest.java
@@ -54,7 +54,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/StaticTrigger.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/StaticTrigger.java
@@ -83,7 +83,7 @@ public class StaticTrigger implements SidelineTrigger {
      * Send a resolve sideline request.
      * @param request sideline request.
      */
-    public static void sendCompleteRequest(final SidelineRequest request) {
+    public static void sendResolveRequest(final SidelineRequest request) {
         StaticTrigger.sidelineController.resolve(request);
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/StaticTrigger.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/StaticTrigger.java
@@ -64,18 +64,26 @@ public class StaticTrigger implements SidelineTrigger {
     }
 
     /**
-     * Start a sideline request.
+     * Send a start sideline request.
      * @param request sideline request.
      */
     public static void sendStartRequest(final SidelineRequest request) {
-        StaticTrigger.sidelineController.startSidelining(request);
+        StaticTrigger.sidelineController.start(request);
     }
 
     /**
-     * Stop a sideline request.
+     * Send a resume sideline request.
      * @param request sideline request.
      */
-    public static void sendStopRequest(final SidelineRequest request) {
-        StaticTrigger.sidelineController.stopSidelining(request);
+    public static void sendResumeRequest(final SidelineRequest request) {
+        StaticTrigger.sidelineController.resume(request);
+    }
+
+    /**
+     * Send a resolve sideline request.
+     * @param request sideline request.
+     */
+    public static void sendCompleteRequest(final SidelineRequest request) {
+        StaticTrigger.sidelineController.resolve(request);
     }
 }

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTriggerTest.java
@@ -139,14 +139,14 @@ public class ZookeeperWatchTriggerTest {
         await()
             .until(() -> findSidelineRequest("start", trigger.getSidelineRequests()), notNullValue());
 
-        Mockito.verify(sidelineSpoutHandler).startSidelining(
+        Mockito.verify(sidelineSpoutHandler).start(
             findSidelineRequest("start", trigger.getSidelineRequests())
         );
 
         final Map<String,Object> stopData = new HashMap<>();
         stopData.put("id", "stop");
         final TriggerEvent stopTriggerEvent = new TriggerEvent(
-            SidelineType.STOP,
+            SidelineType.RESOLVE,
             stopData,
             LocalDateTime.now(),
             CREATED_BY,
@@ -169,7 +169,7 @@ public class ZookeeperWatchTriggerTest {
         await()
             .until(() -> findSidelineRequest("stop", trigger.getSidelineRequests()), notNullValue());
 
-        Mockito.verify(sidelineSpoutHandler).stopSidelining(
+        Mockito.verify(sidelineSpoutHandler).resolve(
             findSidelineRequest("stop", trigger.getSidelineRequests())
         );
 
@@ -252,7 +252,7 @@ public class ZookeeperWatchTriggerTest {
         final Map<String,Object> stopData = new HashMap<>();
         stopData.put("id", "stop");
         final TriggerEvent stopTriggerEvent = new TriggerEvent(
-            SidelineType.STOP,
+            SidelineType.RESOLVE,
             stopData,
             LocalDateTime.now(),
             CREATED_BY,
@@ -282,14 +282,14 @@ public class ZookeeperWatchTriggerTest {
         await()
             .until(() -> findSidelineRequest("start", trigger.getSidelineRequests()), notNullValue());
 
-        Mockito.verify(sidelineSpoutHandler).startSidelining(
+        Mockito.verify(sidelineSpoutHandler).start(
             findSidelineRequest("start", trigger.getSidelineRequests())
         );
 
         await()
             .until(() -> findSidelineRequest("stop", trigger.getSidelineRequests()), notNullValue());
 
-        Mockito.verify(sidelineSpoutHandler).stopSidelining(
+        Mockito.verify(sidelineSpoutHandler).resolve(
             findSidelineRequest("stop", trigger.getSidelineRequests())
         );
 

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -39,6 +39,11 @@
             <AppenderRef ref="File"/>
         </Logger>
 
+        <Logger name="com.salesforce.storm.spout.sideline">
+            <AppenderRef ref="Console" level="ERROR"/>
+            <AppenderRef ref="File" level="INFO"/>
+        </Logger>
+
         <!-- Define our loggers -->
         <Root level="INFO">
             <!-- Only Errors go to console, except for the specific classpaths defined above -->


### PR DESCRIPTION
## Summary
This PR adds a new state to the sideline sequence which we are calling **resume**. 

## Current States
Today sidelines are binary, they can be started or stopped.  Starting a sideline means that a starting offset is captured for a future virtual spout and a filter is applied to the firehose virtual spout.  This is typically done around the concept of a 'tenant', for example you might want to sideline account _Foobar_ for a period of time.  Stopping a sideline means that an ending offset is captured for a virtual spout that will be now created using the starting offset saved during the start of the sideline. That new virtual spout is immediately added to the coordinator with a filter that only emits the tenant in question and the filter is removed altogether from the firehose.

### Potential Problems
The consequences of the binary approach are that ordering gets wildly thrown off and when a sideline stops we are essentially doubling a tenants emitted messages. This can be controlled with a different MessageBuffer, but the underlying problem remains: if a tenant's operations required sidelining we go from 0-60 (or 65) almost immediately without slowing down the emission of data into the main spout.

## New States
Moving forward, and the goal of this PR is to split up the current stopping state into two different states:
1. **Resume:** This state will create a virtual spout using the starting offset from the starting state, and it will use a filter that only emits the given tenant. What's different here is that there is no ending state for the new virtual spout and the firehose still has its tenant filter.
2. **Resolve:** This state will mark the ending offset of the virtual spout for the sideline and remove the filter from the firehose.  When the resolving state is complete (fully resolved) the virtual spout for the sideline should be gone and there should be no filters on the filter chain for the tenant in question.

### Why does this matter?
The primary use we want to support here is throttling of traffic for a single tenant without having to know the ending point.  So by using this new 'resume' state and a MessageBuffer that emits at a slower rate for sidelines, someone could slow the emission of a tenant into the underlying `DynamicSpout`, and then at the point at which they are ready to resume full processing they can set that sideline to 'resolve'.

It's worth noting here that by calling resume() and resolve() back to back you should have the functional equivalent of today's stop() and that nothing is changing with the current start() process.

#### In the Future
Related to this, my suspicion is that this implementation will also give us better mechanics to control the timing of resolving the sideline so that some day in the future we can try to target the sideline once it's _near_ the tail of the firehose (probably using some tolerance level), but that's not the purpose of this PR just an additional thought on why this change makes sense.