### PR TITLE
Remove un-used method from Consumer interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.
+- [PR-81](https://github.com/salesforce/storm-dynamic-spout/pull/81) Removed getPersistenceAdapter() from Consumer interface.
 
 #### Improvements
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing FilterChainSteps.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
@@ -92,8 +92,6 @@ public interface Consumer {
     // The following methods are likely to be removed in future refactorings.
     void removeConsumerState();
 
-    PersistenceAdapter getPersistenceAdapter();
-
     // Maybe the logic in VSpout that needs this can be refactored within KafkaConsumer?
     boolean unsubscribeConsumerPartition(final ConsumerPartition consumerPartitionToUnsubscribe);
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/Consumer.java
@@ -89,9 +89,15 @@ public interface Consumer {
      */
     ConsumerState flushConsumerState();
 
-    // The following methods are likely to be removed in future refactorings.
+    /**
+     * Cleanup internal consumer state relating to the instance.
+     */
     void removeConsumerState();
 
-    // Maybe the logic in VSpout that needs this can be refactored within KafkaConsumer?
+    /**
+     * Requests that the consumer stop consuming from the specified ConsumerPartition.
+     * @param consumerPartitionToUnsubscribe Consumer Partition to stop consuming from.
+     * @return true if unsubscribed, false if not.
+     */
     boolean unsubscribeConsumerPartition(final ConsumerPartition consumerPartitionToUnsubscribe);
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/kafka/Consumer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/kafka/Consumer.java
@@ -650,7 +650,7 @@ public class Consumer implements com.salesforce.storm.spout.dynamic.consumer.Con
     /**
      * @return PersistenceAdapter instance.
      */
-    public PersistenceAdapter getPersistenceAdapter() {
+    PersistenceAdapter getPersistenceAdapter() {
         return persistenceAdapter;
     }
 

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -1327,16 +1327,12 @@ public class VirtualSpoutTest {
     @Test
     public void testCloseWithCompletedFlagSetToFalse() throws NoSuchFieldException, IllegalAccessException {
         // Create inputs
-        final Map topologyConfig = getDefaultConfig();
+        final Map<String, Object> topologyConfig = getDefaultConfig();
         final TopologyContext mockTopologyContext = new MockTopologyContext();
         final SidelineRequestIdentifier sidelineRequestId = new SidelineRequestIdentifier("SidelineRequestId");
 
         // Create a mock SidelineConsumer
         final Consumer mockConsumer = mock(Consumer.class);
-
-        // Create a mock PersistanceManager & associate with SidelineConsumer.
-        final PersistenceAdapter mockPersistenceAdapter = mock(PersistenceAdapter.class);
-        when(mockConsumer.getPersistenceAdapter()).thenReturn(mockPersistenceAdapter);
 
         // Create factory manager
         final FactoryManager factoryManager = spy(new FactoryManager(topologyConfig));
@@ -1380,17 +1376,13 @@ public class VirtualSpoutTest {
     @Test
     public void testCloseWithCompletedFlagSetToTrue() throws NoSuchFieldException, IllegalAccessException {
         // Create inputs
-        final Map topologyConfig = getDefaultConfig();
+        final Map<String, Object> topologyConfig = getDefaultConfig();
         topologyConfig.put(SpoutConfig.VIRTUAL_SPOUT_HANDLER_CLASS, SidelineVirtualSpoutHandler.class.getName());
         final TopologyContext mockTopologyContext = new MockTopologyContext();
         final SidelineRequestIdentifier sidelineRequestId = new SidelineRequestIdentifier("SidelineRequestId");
 
         // Create a mock SidelineConsumer
         final Consumer mockConsumer = mock(Consumer.class);
-
-        // Create a mock PersistanceManager & associate with SidelineConsumer.
-        final PersistenceAdapter mockPersistenceAdapter = mock(PersistenceAdapter.class);
-        when(mockConsumer.getPersistenceAdapter()).thenReturn(mockPersistenceAdapter);
 
         // Create factory manager
         final FactoryManager factoryManager = spy(new FactoryManager(topologyConfig));
@@ -1438,15 +1430,11 @@ public class VirtualSpoutTest {
     @Test
     public void testCloseWithCompletedFlagSetToTrueNoSidelineREquestIdentifier() throws NoSuchFieldException, IllegalAccessException {
         // Create inputs
-        final Map topologyConfig = getDefaultConfig();
+        final Map<String, Object> topologyConfig = getDefaultConfig();
         final TopologyContext mockTopologyContext = new MockTopologyContext();
 
         // Create a mock SidelineConsumer
         final Consumer mockConsumer = mock(Consumer.class);
-
-        // Create a mock PersistanceManager & associate with SidelineConsumer.
-        final PersistenceAdapter mockPersistenceAdapter = mock(PersistenceAdapter.class);
-        when(mockConsumer.getPersistenceAdapter()).thenReturn(mockPersistenceAdapter);
 
         // Create factory manager
         final FactoryManager factoryManager = spy(new FactoryManager(topologyConfig));

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
@@ -115,12 +115,7 @@ public class MockConsumer implements Consumer {
     public void removeConsumerState() {
 
     }
-
-    @Override
-    public PersistenceAdapter getPersistenceAdapter() {
-        return persistenceAdapter;
-    }
-
+    
     @Override
     public boolean unsubscribeConsumerPartition(ConsumerPartition consumerPartitionToUnsubscribe) {
         return false;


### PR DESCRIPTION
We never reference this public interface method, so lets remove it from the interface.