### PR TITLE
Fix ordering bug in DefaultRetryManager.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added `isSidelineStarted()` and `isSidelineStopped()` to the `SidelineController`
 - [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them.
-- [PR-XX]() Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId. 
+- [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId. 
 
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing `FilterChainStep` objects. 
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added `isSidelineStarted()` and `isSidelineStopped()` to the `SidelineController`
-- [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them. 
+- [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them.
+- [PR-XX]() Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId. 
 
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
@@ -184,10 +184,11 @@ public class DefaultRetryManager implements RetryManager {
         }
 
         // Populate the values
-        final Long lowestTimestampKey = entry.getKey();
+        final long lowestTimestampKey = entry.getKey();
         final Queue<MessageId> queue = entry.getValue();
 
-        // Determine if the key (timestamp) has expired (is less than now)
+        // Determine if the key (timestamp) has expired or not
+        // Here we define 'expired' as having a timestamp less than or equal to now.
         if (lowestTimestampKey > now) {
             // Nothing has expired.
             return null;
@@ -202,7 +203,7 @@ public class DefaultRetryManager implements RetryManager {
             failedMessageIds.remove(lowestTimestampKey);
         }
 
-        // Mark this tuple as now in flight.
+        // Mark this messageId as now in flight.
         retriesInFlight.add(messageId);
         return messageId;
     }


### PR DESCRIPTION
Previously the implementation would return messageIds that were closest to the current timestamp instead of the messageIds which failed earlier.  This means if there was a high rate of sustained failures, the earlier failed messageIds may never have gotten replayed.