### PR TITLE
Check for nulls and log accordingly

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -301,6 +301,16 @@ public class SidelineSpoutHandler implements SpoutHandler {
 
             logger.info("Loaded sideline payload for {} = {}", consumerPartition, sidelinePayload);
 
+            if (sidelinePayload == null) {
+                logger.error("Attempting to load sideline {} for partition {} and it was null.", id, consumerPartition.partition());
+                continue;
+            }
+
+            if (sidelinePayload.startingOffset == null) {
+                logger.error("Loaded sideline {} for partition {} but the starting offset was null", id, consumerPartition.partition());
+                continue;
+            }
+
             // Add this partition to the starting consumer state
             startingStateBuilder.withPartition(consumerPartition, sidelinePayload.startingOffset);
 


### PR DESCRIPTION
Add checks and skip in loop if this should happen. This most likely occurs when there's bad serialization occurring on sideline requests.