### PR TITLE
More fair partition distribution with weird number of partitions

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
@@ -94,13 +94,13 @@ public class PartitionDistributor {
             }
 
             // How many consumer instances remain?
-            final int reaminingConsumerSlots = totalConsumers - consumerInstance;
+            final int remainingConsumerSlots = totalConsumers - consumerInstance;
 
             // We we have more slots than remaining partitions we advance to the next consumer.
             // This usually means that we have a weird number of partitions to balance across instances, like four partitions
             // across three instances, which means that last two instances will have only one partition, though the maximum
             // could be two instances. If this part confuses you, check out the test for this class.
-            if (reaminingConsumerSlots > remainingPartitions) {
+            if (remainingConsumerSlots > remainingPartitions) {
                 consumerInstance++;
             }
         }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
@@ -26,9 +26,11 @@
 package com.salesforce.storm.spout.dynamic.consumer;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility for calculating the distribution of a set of partition ids to a given consumer.
@@ -62,25 +64,48 @@ public class PartitionDistributor {
         // Sort our partitions
         Arrays.sort(allPartitionIds);
 
-        // Determine the maximum number of partitions that a given consumer instance should have
-        final int partitionsPerInstance = (int) Math.ceil((double) allPartitionIds.length / totalConsumers);
+        // Determine the maximum number of partitions that a given consumer instance could have
+        final int maxPartitionsPerInstance = (int) Math.ceil((double) allPartitionIds.length / totalConsumers);
 
-        // Determine our starting point in the list of instances
-        final int startingPartition = consumerIndex == 0 ? 0 : partitionsPerInstance * consumerIndex;
+        // We are going to sort our partitions across all consumer indexes
+        final Map<Integer,List<Integer>> partitionByConsumer = Maps.newHashMap();
 
-        // Determine our ending point in the list of instances
-        final int endingPartition = startingPartition + partitionsPerInstance > allPartitionIds.length
-            ? allPartitionIds.length : startingPartition + partitionsPerInstance;
-
-        // Make a new array of integers for the partition ids
-        List<Integer> partitionIds = Lists.newArrayList();
-
-        // Loop over our segment of all the partitions and add just the ones we need to our array
-        for (int i = startingPartition; i < endingPartition; i++) {
-            partitionIds.add(allPartitionIds[i]);
+        // Add a list for each consumer
+        for (int i=0; i<totalConsumers; i++) {
+            partitionByConsumer.put(i, Lists.newArrayList());
         }
 
-        // Convert to an array of primitive ints and return them
-        return partitionIds.stream().mapToInt(i -> i).toArray();
+        // Tracks the current consumer instance we are handing partitions to
+        int consumerInstance = 0;
+        // Number of remaining partitions, we'll start with all of them
+        int remainingPartitions = allPartitionIds.length;
+
+        for (final int partitionId : allPartitionIds) {
+            // Add our current partition to the current consumer instance
+            partitionByConsumer.get(consumerInstance).add(partitionId);
+
+            // We now have one less partition to dole out
+            remainingPartitions--;
+
+            // If we've reached our maximum number of partitions per instance, advance to the next instance
+            // This means that an instance gets partitions in order, eg. [0, 1] and [2, 3], etc.
+            if (partitionByConsumer.get(consumerInstance).size() >= maxPartitionsPerInstance) {
+                consumerInstance++;
+            }
+
+            // How many consumer instances remain?
+            final int reaminingConsumerSlots = totalConsumers - consumerInstance;
+
+            // We we have more slots than remaining partitions we advance to the next consumer.
+            // This usually means that we have a weird number of partitions to balance across instances, like four partitions
+            // across three instances, which means that last two instances will have only one partition, though the maximum
+            // could be two instances. If this part confuses you, check out the test for this class.
+            if (reaminingConsumerSlots > remainingPartitions) {
+                consumerInstance++;
+            }
+        }
+
+        // Grab the partitions for our current consumer and make an array of primitives of them
+        return partitionByConsumer.get(consumerIndex).stream().mapToInt(i -> i).toArray();
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributor.java
@@ -71,7 +71,7 @@ public class PartitionDistributor {
         final Map<Integer,List<Integer>> partitionByConsumer = Maps.newHashMap();
 
         // Add a list for each consumer
-        for (int i=0; i<totalConsumers; i++) {
+        for (int i = 0; i < totalConsumers; i++) {
             partitionByConsumer.put(i, Lists.newArrayList());
         }
 

--- a/src/test/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributorTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributorTest.java
@@ -80,8 +80,6 @@ public class PartitionDistributorTest {
      */
     @DataProvider
     public static Object[][] dataProvider() {
-        final int[] partitions35 = new int[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34 };
-
         return new Object[][]{
             // Two instances, first instance, two partitions, first partition
             { 2, 0, new int[]{ 0 , 1 }, new int[]{ 0 } },

--- a/src/test/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributorTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/consumer/PartitionDistributorTest.java
@@ -32,6 +32,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -40,6 +42,9 @@ import static org.junit.Assert.assertArrayEquals;
  */
 @RunWith(DataProviderRunner.class)
 public class PartitionDistributorTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(PartitionDistributorTest.class);
+
 
     /**
      * Test that given a number of consumer instances the current instance gets distributed the correct set of partition ids.
@@ -60,6 +65,8 @@ public class PartitionDistributorTest {
             allPartitionIds
         );
 
+        logger.info("Expected = {}, Actual = {}", expectedPartitionIds, actualPartitionIds);
+
         assertArrayEquals(
             "Partition ids match",
             expectedPartitionIds,
@@ -73,6 +80,8 @@ public class PartitionDistributorTest {
      */
     @DataProvider
     public static Object[][] dataProvider() {
+        final int[] partitions35 = new int[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34 };
+
         return new Object[][]{
             // Two instances, first instance, two partitions, first partition
             { 2, 0, new int[]{ 0 , 1 }, new int[]{ 0 } },
@@ -84,6 +93,12 @@ public class PartitionDistributorTest {
             { 1, 0, new int[]{ 0, 1, 2 }, new int[]{ 0, 1, 2 } },
             // One instance, first instance, three partitions not in order, all partitions
             { 1, 0, new int[]{ 2, 0, 1 }, new int[]{ 0, 1, 2 } },
+            // Three instances, first instance, four partitions, first two partitions
+            { 3, 0, new int[]{ 0, 1, 2, 3 }, new int[]{ 0, 1 } },
+            // Three instances, second instance, four partitions, third partition
+            { 3, 1, new int[]{ 0, 1, 2, 3 }, new int[]{ 2 } },
+            // Three instances, third instance, four partitions, fourth partition
+            { 3, 2, new int[]{ 0, 1, 2, 3 }, new int[]{ 3 } },
         };
     }
 


### PR DESCRIPTION
The current partition distribution implementation attempts to distribute the maximum number of partitions to each consumer, such that when the number of consumer instances is not a multiplier of the partition count the ending instances are left with no partitions.  For example consider 4 partitions across 3 instances, the current implementation will give instances 1 & 2 two partitions each and leave instance 3 with no partitions.

The new implementation attempts to make sure every instance has at least one partition, unless there are more instances than partitions, and will distribute up to the max partition per instance number to as many instances as it can.  The trick here is that we still want the partitions ordered such that with 4 partitions across 3 instances, instance 1 should have partitions 0 and 1, and instance 2 should have partition 2 and instance 3 partition 4.  The complexity here is easier to see when you go up to 20 instances and 35 partitions as an example.  The current implementation would leave the last two instances empty, when it reality we want them each to have one.