### PR TITLE
First pass at a permanently failed output stream from the spout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Replaced `SidelineRequestIdentifier` with `FilterChainStepIdentifier` in the FilterChain.
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added `isSidelineStarted()` and `isSidelineStopped()` to the `SidelineController`
 - [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them.
-- [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId. 
+- [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId.
+- [PR-90](https://github.com/salesforce/storm-dynamic-spout/pull/90) Adds new 'Permanently Failed' output stream.  Tuples that exceed the configured retry limit will now be emitted out a 'failed' stream un-anchored. This allows you to do your own error handling within the topology by subscribing to this stream. The name of this output stream defaults to 'failed', but is configurable via the `spout.permanently_failed_output_stream_id` configuration item.
 
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ The following implementations of previously mentioned interfaces are provided wi
 
 [NeverRetryManager](src/main/java/com/salesforce/storm/spout/dynamic/retry/NeverRetryManager.java) - This implementation will never retry failed messages.  One and done.
 
+A tuple is considered "permanently failed" when the topology has attempted to process the tuple at least once and the RetryManager
+implementation has determined that the tuple should not be retried. When this occurs, the tuple will be emitted un-anchored out
+a "failed" stream. Bolts within the topology can subscribe to this "failed" stream and do its own error handling. The name of this stream is
+configured via the `spout.permanently_failed_output_stream_id` setting, and if undefined defaults simply to `failed` 
+
 ### MessageBuffer Implementations
 [RoundRobinBuffer](src/main/java/com/salesforce/storm/spout/dynamic/buffer/RoundRobinBuffer.java) - This is the default implementation, which is essentially round-robin.  Each `VirtualSpout` has its own queue that gets added to.  A very chatty virtual spout will not block/overrun less chatty ones.  The `poll()` method will round robin through all the available queues to get the next msg.
  

--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -516,7 +516,13 @@ public class DynamicSpout extends BaseRichSpout {
      */
     String getPermanentlyFailedOutputStreamId() {
         if (permanentlyFailedOutputStreamId == null) {
-            permanentlyFailedOutputStreamId = getOutputStreamId() + "_failed";
+            if (spoutConfig == null) {
+                throw new IllegalStateException("Missing required configuration! SpoutConfig not defined!");
+            }
+            permanentlyFailedOutputStreamId = (String) getSpoutConfigItem(SpoutConfig.PERMANENTLY_FAILED_OUTPUT_STREAM_ID);
+            if (Strings.isNullOrEmpty(permanentlyFailedOutputStreamId)) {
+                permanentlyFailedOutputStreamId = "failed";
+            }
         }
         return permanentlyFailedOutputStreamId;
     }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
@@ -43,6 +43,12 @@ public class Message {
      */
     private final Values values;
 
+    /**
+     * Determines if this message should be considered 'Permanently Failed.'
+     * We're defining "permanently failed" meaning that the topology attempted to process the tuple at least once and the RetryManager
+     * implementation has determined that the tuple should never be retried. When this occurs, the tuple will be emitted un-anchored out
+     * a "failed" stream. Bolts within the topology can subscribe to this "failed" stream and do its own error handling.
+     */
     private final boolean isPermanentlyFailed;
 
     /**
@@ -113,6 +119,9 @@ public class Message {
         Message that = (Message) other;
 
         if (!getMessageId().equals(that.getMessageId())) {
+            return false;
+        }
+        if (isPermanentlyFailed() != that.isPermanentlyFailed()) {
             return false;
         }
         return getValues().equals(that.getValues());

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
@@ -43,14 +43,21 @@ public class Message {
      */
     private final Values values;
 
+    private final boolean hasFailed;
+
     /**
-     * Constructor.
-     * @param messageId - contains information about what Topic, Partition, Offset, and Consumer this
-     * @param values - contains the values that will be emitted out to the Storm Topology.
+     * Constructor for non-failed messages.
+     * @param messageId contains information about what Topic, Partition, Offset, and Consumer this
+     * @param values contains the values that will be emitted out to the Storm Topology.
      */
-    public Message(MessageId messageId, Values values) {
+    public Message(final MessageId messageId, final Values values) {
+        this(messageId, values, false);
+    }
+
+    private Message(final MessageId messageId, final Values values, final boolean hasFailed) {
         this.messageId = messageId;
         this.values = values;
+        this.hasFailed = hasFailed;
     }
 
     public MessageId getMessageId() {
@@ -73,12 +80,17 @@ public class Message {
         return values;
     }
 
+    public boolean isHasFailed() {
+        return hasFailed;
+    }
+
     @Override
     public String toString() {
         return "Message{"
-                + "messageId=" + messageId
-                + ", values=" + values
-                + '}';
+            + "messageId=" + messageId
+            + ", values=" + values
+            + ", hasFailed=" + hasFailed
+            + '}';
     }
 
     @Override
@@ -103,5 +115,9 @@ public class Message {
         int result = getMessageId().hashCode();
         result = 31 * result + getValues().hashCode();
         return result;
+    }
+
+    public static Message createFailedMessage(final Message message) {
+        return new Message(message.getMessageId(), message.getValues(), true);
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Message.java
@@ -43,10 +43,10 @@ public class Message {
      */
     private final Values values;
 
-    private final boolean hasFailed;
+    private final boolean isPermanentlyFailed;
 
     /**
-     * Constructor for non-failed messages.
+     * Constructor.
      * @param messageId contains information about what Topic, Partition, Offset, and Consumer this
      * @param values contains the values that will be emitted out to the Storm Topology.
      */
@@ -54,10 +54,18 @@ public class Message {
         this(messageId, values, false);
     }
 
-    private Message(final MessageId messageId, final Values values, final boolean hasFailed) {
+    /**
+     * Private constructor.  Allows for creating permanently failed messages.
+     * Use the Factory method to create permanently failed messages.
+     *
+     * @param messageId contains information about what Topic, Partition, Offset, and Consumer this
+     * @param values contains the values that will be emitted out to the Storm Topology.
+     * @param hasPermanentlyFailed True if it has failed permanently, false if not.
+     */
+    private Message(final MessageId messageId, final Values values, final boolean hasPermanentlyFailed) {
         this.messageId = messageId;
         this.values = values;
-        this.hasFailed = hasFailed;
+        this.isPermanentlyFailed = hasPermanentlyFailed;
     }
 
     public MessageId getMessageId() {
@@ -80,8 +88,8 @@ public class Message {
         return values;
     }
 
-    public boolean isHasFailed() {
-        return hasFailed;
+    public boolean isPermanentlyFailed() {
+        return isPermanentlyFailed;
     }
 
     @Override
@@ -89,7 +97,7 @@ public class Message {
         return "Message{"
             + "messageId=" + messageId
             + ", values=" + values
-            + ", hasFailed=" + hasFailed
+            + ", isPermanentlyFailed=" + isPermanentlyFailed
             + '}';
     }
 
@@ -117,7 +125,12 @@ public class Message {
         return result;
     }
 
-    public static Message createFailedMessage(final Message message) {
+    /**
+     * Factory method to create a permanently failed message from an existing message.
+     * @param message Message to make permanently failed.
+     * @return A new Message object that is marked as permanently failed.
+     */
+    public static Message createPermanentlyFailedMessage(final Message message) {
         return new Message(message.getMessageId(), message.getValues(), true);
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java
@@ -284,8 +284,8 @@ public class VirtualSpout implements DelegateSpout {
 
         // Determine if we have any permanently failed messages queued.
         if (!permanentlyFailedMessages.isEmpty()) {
-            // Emit a failed message
-            return Message.createFailedMessage(permanentlyFailedMessages.poll());
+            // Emit the permanently failed message
+            return permanentlyFailedMessages.poll();
         }
 
         // Grab the next message from Consumer instance.
@@ -417,7 +417,7 @@ public class VirtualSpout implements DelegateSpout {
             final Message message = trackedMessages.get(messageId);
             if (message != null) {
                 // Add to permanently failed queue.
-                permanentlyFailedMessages.add(message);
+                permanentlyFailedMessages.add(Message.createPermanentlyFailedMessage(message));
             }
 
             // Call ack on the messageId

--- a/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/config/SpoutConfig.java
@@ -69,6 +69,15 @@ public class SpoutConfig {
     )
     public static final String OUTPUT_FIELDS = "spout.output_fields";
 
+    /**
+     * (String) Defines the name of the output stream tuples that have permanently failed will be emitted out of.
+     */
+    @ConfigDocumentation(
+        category = ConfigDocumentation.Category.DYNAMIC_SPOUT,
+        description = "Defines the name of the output stream tuples that have permanently failed be emitted out of.",
+        type = String.class
+    )
+    public static final String PERMANENTLY_FAILED_OUTPUT_STREAM_ID = "spout.permanently_failed_output_stream_id";
 
 
 ///////////////////////////////////
@@ -444,6 +453,14 @@ public class SpoutConfig {
                 "Unspecified configuration value for {} using default value {}",
                 OUTPUT_STREAM_ID,
                 clonedConfig.get(OUTPUT_STREAM_ID)
+            );
+        }
+        if (!clonedConfig.containsKey(PERMANENTLY_FAILED_OUTPUT_STREAM_ID)) {
+            clonedConfig.put(PERMANENTLY_FAILED_OUTPUT_STREAM_ID, "failed");
+            logger.info(
+                "Unspecified configuration value for {} using default value {}",
+                PERMANENTLY_FAILED_OUTPUT_STREAM_ID,
+                clonedConfig.get(PERMANENTLY_FAILED_OUTPUT_STREAM_ID)
             );
         }
         if (!clonedConfig.containsKey(CONSUMER_CLASS)) {

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -455,7 +455,7 @@ public class DynamicSpoutTest {
 
         // Define our output stream id
         final String expectedStreamId = "default";
-        final String expectedFailedStreamId = "default_failed";
+        final String expectedFailedStreamId = "failed";
 
         // Create our config
         final Map<String, Object> config = getDefaultConfig(consumerIdPrefix, expectedStreamId);
@@ -801,7 +801,7 @@ public class DynamicSpoutTest {
         );
 
         // Validate permanently failed output stream
-        final String defaultFailedStreamId = Utils.DEFAULT_STREAM_ID + "_failed";
+        final String defaultFailedStreamId = "failed";
         assertTrue(fieldsDeclaration.containsKey(defaultFailedStreamId));
         assertEquals(
             fieldsDeclaration.get(defaultFailedStreamId).get_output_fields(),
@@ -823,7 +823,7 @@ public class DynamicSpoutTest {
     @UseDataProvider("provideOutputFields")
     public void testDeclareOutputFields_with_stream(final Object inputFields, final String[] expectedFields) {
         final String streamId = "foobar";
-        final String failedStreamId = streamId + "_failed";
+        final String failedStreamId = "failed";
         final Map<String,Object> config = getDefaultConfig("DynamicSpout-", streamId);
 
         // Define our output fields as key and value.

--- a/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/DynamicSpoutTest.java
@@ -474,7 +474,11 @@ public class DynamicSpoutTest {
 
         // validate our streamId
         assertEquals("Should be using appropriate output stream id", expectedStreamId, spout.getOutputStreamId());
-        assertEquals("Should be using appropriate failed output stream id", expectedFailedStreamId, spout.getPermanentlyFailedOutputStreamId());
+        assertEquals(
+            "Should be using appropriate failed output stream id",
+            expectedFailedStreamId,
+            spout.getPermanentlyFailedOutputStreamId()
+        );
 
         // Create new unique VSpoutId
         final VirtualSpoutIdentifier virtualSpoutIdentifier =

--- a/src/test/java/com/salesforce/storm/spout/dynamic/MessageTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/MessageTest.java
@@ -49,7 +49,6 @@ public class MessageTest {
         final DefaultVirtualSpoutIdentifier expectedConsumerId = new DefaultVirtualSpoutIdentifier("MyConsumerId");
         final MessageId expectedMessageId = new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId);
 
-
         // Define expected values components
         final String expectedValue1 = "This is value 1";
         final String expectedValue2 = "This is value 2";
@@ -64,6 +63,7 @@ public class MessageTest {
         assertEquals("Got expected namespace", expectedTopic, message.getNamespace());
         assertEquals("Got expected partition", expectedPartition, message.getPartition());
         assertEquals("Got expected offset", expectedOffset, message.getOffset());
+        assertFalse("Should not be permanently failed", message.isPermanentlyFailed());
 
         // Validate Values
         assertEquals("Got expected Values", expectedValues, message.getValues());
@@ -71,6 +71,45 @@ public class MessageTest {
         assertEquals("Got expected Value1", expectedValue1, message.getValues().get(0));
         assertEquals("Got expected Value2", expectedValue2, message.getValues().get(1));
         assertEquals("Got expected Value3", expectedValue3, message.getValues().get(2));
+    }
+
+    /**
+     * Tests the constructor + getters.
+     */
+    @Test
+    public void testCreatePermanentlyFailedMessage() {
+        // Define TupleMessageId components
+        final String expectedTopic = "MyTopic";
+        final int expectedPartition = 2;
+        final long expectedOffset = 31337L;
+        final DefaultVirtualSpoutIdentifier expectedConsumerId = new DefaultVirtualSpoutIdentifier("MyConsumerId");
+        final MessageId expectedMessageId = new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId);
+
+        // Define expected values components
+        final String expectedValue1 = "This is value 1";
+        final String expectedValue2 = "This is value 2";
+        final Long expectedValue3 = 42L;
+        final Values expectedValues = new Values(expectedValue1, expectedValue2, expectedValue3);
+
+        // Create Message
+        final Message message = new Message(expectedMessageId, expectedValues);
+
+        // Mark it as permanently failed
+        final Message failedMessage = Message.createPermanentlyFailedMessage(message);
+
+        // Validate TupleMessageId
+        assertEquals("Got expected TupleMessageId", expectedMessageId, failedMessage.getMessageId());
+        assertEquals("Got expected namespace", expectedTopic, failedMessage.getNamespace());
+        assertEquals("Got expected partition", expectedPartition, failedMessage.getPartition());
+        assertEquals("Got expected offset", expectedOffset, failedMessage.getOffset());
+        assertTrue("Should be permanently failed", failedMessage.isPermanentlyFailed());
+
+        // Validate Values
+        assertEquals("Got expected Values", expectedValues, failedMessage.getValues());
+        assertEquals("Got expected Values count", 3, failedMessage.getValues().size());
+        assertEquals("Got expected Value1", expectedValue1, failedMessage.getValues().get(0));
+        assertEquals("Got expected Value2", expectedValue2, failedMessage.getValues().get(1));
+        assertEquals("Got expected Value3", expectedValue3, failedMessage.getValues().get(2));
     }
 
     /**
@@ -217,6 +256,72 @@ public class MessageTest {
         // Validate
         assertTrue("Should be equal", message1.equals(message2));
         assertTrue("Should be equal", message2.equals(message1));
+    }
+
+    /**
+     * Tests equality.
+     */
+    @Test
+    public void testNotEqualsOneIsFailedDifferentInstances() {
+        // Define TupleMessageId components
+        final String expectedTopic = "MyTopic";
+        final int expectedPartition = 2;
+        final long expectedOffset = 31337L;
+        final DefaultVirtualSpoutIdentifier expectedConsumerId = new DefaultVirtualSpoutIdentifier("MyConsumerId");
+
+        // Define expected values components
+        final String expectedValue1 = "This is value 1";
+        final String expectedValue2 = "This is value 2";
+        final Long expectedValue3 = 42L;
+
+        // Create Message
+        final Message message1 = new Message(
+            new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId),
+            new Values(expectedValue1, expectedValue2, expectedValue3)
+        );
+
+        // Create Message
+        final Message message2 = Message.createPermanentlyFailedMessage(new Message(
+            new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId),
+            new Values(expectedValue1, expectedValue2, expectedValue3)
+        ));
+
+        // Validate
+        assertFalse("Should not be equal", message1.equals(message2));
+        assertFalse("Should not be equal", message2.equals(message1));
+    }
+
+    /**
+     * Tests equality.
+     */
+    @Test
+    public void testEqualsBothAreFailedDifferentInstances() {
+        // Define TupleMessageId components
+        final String expectedTopic = "MyTopic";
+        final int expectedPartition = 2;
+        final long expectedOffset = 31337L;
+        final DefaultVirtualSpoutIdentifier expectedConsumerId = new DefaultVirtualSpoutIdentifier("MyConsumerId");
+
+        // Define expected values components
+        final String expectedValue1 = "This is value 1";
+        final String expectedValue2 = "This is value 2";
+        final Long expectedValue3 = 42L;
+
+        // Create Message
+        final Message message1 = Message.createPermanentlyFailedMessage(new Message(
+            new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId),
+            new Values(expectedValue1, expectedValue2, expectedValue3)
+        ));
+
+        // Create Message
+        final Message message2 = Message.createPermanentlyFailedMessage(new Message(
+            new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId),
+            new Values(expectedValue1, expectedValue2, expectedValue3)
+        ));
+
+        // Validate
+        assertTrue("Should not be equal", message1.equals(message2));
+        assertTrue("Should not be equal", message2.equals(message1));
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -278,8 +278,13 @@ public class VirtualSpoutTest {
         );
 
         // Set expected exception
-        expectedExceptionCallingOpenTwiceThrowsException.expect(IllegalStateException.class);
-        virtualSpout.open();
+        try {
+            expectedExceptionCallingOpenTwiceThrowsException.expect(IllegalStateException.class);
+            virtualSpout.open();
+        } finally {
+            // Ensure that we call close.
+            virtualSpout.close();
+        }
     }
 
     /**
@@ -340,6 +345,9 @@ public class VirtualSpoutTest {
             eq(metricsRecorder),
             eq(null)
         );
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -387,6 +395,9 @@ public class VirtualSpoutTest {
 
         // Verify ack is never called on underlying mock consumer
         verify(mockConsumer, never()).commitOffset(anyString(), anyInt(), anyLong());
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -429,6 +440,9 @@ public class VirtualSpoutTest {
 
         // Verify its null
         assertNull("Should be null",  result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -491,6 +505,9 @@ public class VirtualSpoutTest {
 
         // Verify ack was called on the tuple
         verify(mockConsumer, times(1)).commitOffset(eq(expectedTopic), eq(expectedPartition), eq(expectedOffset));
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -558,6 +575,9 @@ public class VirtualSpoutTest {
         assertEquals("Found expected offset", expectedOffset, result.getOffset());
         assertEquals("Found expected values", new Values(expectedKey, expectedValue), result.getValues());
         assertEquals("Got expected Message", expectedMessage, result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -686,6 +706,9 @@ public class VirtualSpoutTest {
         // Validate that we never called ack on the tuples that were filtered because they exceeded the max offset
         verify(mockConsumer, times(0)).commitOffset(topic, partition, afterOffset);
         verify(mockConsumer, times(0)).commitOffset(topic, partition, afterOffset + 1);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -749,7 +772,7 @@ public class VirtualSpoutTest {
         final Consumer mockConsumer = mock(Consumer.class);
 
         // When nextRecord() is called on the mockSidelineConsumer, we need to return a value
-        when(mockConsumer.nextRecord()).thenReturn(expectedConsumerRecord, unexpectedConsumerRecord);
+        when(mockConsumer.nextRecord()).thenReturn(expectedConsumerRecord, unexpectedConsumerRecord, null);
 
         // Create a mock RetryManager
         final RetryManager mockRetryManager = mock(RetryManager.class);
@@ -790,6 +813,7 @@ public class VirtualSpoutTest {
         assertEquals("Found expected offset", expectedOffset, result.getOffset());
         assertEquals("Found expected values", new Values(expectedKey, expectedValue), result.getValues());
         assertEquals("Got expected Message", expectedMessage, result);
+        assertFalse("Should not be permanently failed", result.isPermanentlyFailed());
 
         // Now call fail on this
         final MessageId failedMessageId = result.getMessageId();
@@ -821,6 +845,7 @@ public class VirtualSpoutTest {
         assertEquals("Found expected offset", expectedOffset, result.getOffset());
         assertEquals("Found expected values", new Values(expectedKey, expectedValue), result.getValues());
         assertEquals("Got expected Message", expectedMessage, result);
+        assertFalse("Should not be permanently failed", result.isPermanentlyFailed());
 
         // And call nextTuple() one more time, this time failed manager should return null
         // and consumer returns our unexpected result
@@ -839,6 +864,28 @@ public class VirtualSpoutTest {
         assertEquals("Found expected offset", unexpectedOffset, result.getOffset());
         assertEquals("Found expected values", new Values(unexpectedKey, unexpectedValue), result.getValues());
         assertEquals("Got expected Message", unexpectedMessage, result);
+
+        // Next Tuple should return null
+        assertNull("No more tuples queued", virtualSpout.nextTuple());
+
+        // Now test calling fail on our failed tuple, retry manager should say this is enough,
+        when(mockRetryManager.retryFurther(failedMessageId)).thenReturn(false);
+        virtualSpout.fail(failedMessageId);
+
+        // When we call next Tuple() we should get our failed message, marked as permanently failed
+        result = virtualSpout.nextTuple();
+        assertNotNull("Should have non-null message", result);
+
+        // Validate it
+        assertEquals("Found expected namespace", expectedTopic, result.getNamespace());
+        assertEquals("Found expected partition", expectedPartition, result.getPartition());
+        assertEquals("Found expected offset", expectedOffset, result.getOffset());
+        assertEquals("Found expected values", new Values(expectedKey, expectedValue), result.getValues());
+        assertEquals("Got expected MessageId", expectedMessage.getMessageId(), result.getMessageId());
+        assertTrue("Should be permanently failed", result.isPermanentlyFailed());
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -882,6 +929,9 @@ public class VirtualSpoutTest {
         verify(mockRetryManager, never()).acked(anyObject());
         verify(mockRetryManager, never()).failed(anyObject());
         verify(mockConsumer, never()).commitOffset(anyString(), anyInt(), anyLong());
+
+        // Call close
+        virtualSpout.close();
     }
 
     @Rule
@@ -918,8 +968,13 @@ public class VirtualSpoutTest {
         virtualSpout.open();
 
         // Call ack with a string object, it should throw an exception.
-        expectedExceptionFailWithInvalidMsgIdObject.expect(IllegalArgumentException.class);
-        virtualSpout.fail("This is a String!");
+        try {
+            expectedExceptionFailWithInvalidMsgIdObject.expect(IllegalArgumentException.class);
+            virtualSpout.fail("This is a String!");
+        } finally {
+            // Call close
+            virtualSpout.close();
+        }
     }
 
     /**
@@ -961,6 +1016,9 @@ public class VirtualSpoutTest {
         // No interactions w/ our mock consumer for committing offsets
         verify(mockConsumer, never()).commitOffset(anyString(), anyInt(), anyLong());
         verify(mockRetryManager, never()).acked(anyObject());
+
+        // Call close
+        virtualSpout.close();
     }
 
     @Rule
@@ -997,8 +1055,13 @@ public class VirtualSpoutTest {
         virtualSpout.open();
 
         // Call ack with a string object, it should throw an exception.
-        expectedExceptionAckWithInvalidMsgIdObject.expect(IllegalArgumentException.class);
-        virtualSpout.ack("This is my String!");
+        try {
+            expectedExceptionAckWithInvalidMsgIdObject.expect(IllegalArgumentException.class);
+            virtualSpout.ack("This is my String!");
+        } finally {
+            // Call close
+            virtualSpout.close();
+        }
     }
 
     /**
@@ -1054,6 +1117,9 @@ public class VirtualSpoutTest {
 
         // Gets acked on the failed retry manager
         verify(mockRetryManager, times(1)).acked(messageId);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1097,6 +1163,9 @@ public class VirtualSpoutTest {
         // Call our method & validate.
         final boolean result = virtualSpout.doesMessageExceedEndingOffset(messageId);
         assertFalse("Should always be false", result);
+
+        // Close things out
+        virtualSpout.close();
     }
 
     /**
@@ -1141,6 +1210,9 @@ public class VirtualSpoutTest {
         // Call our method & validate.
         final boolean result = virtualSpout.doesMessageExceedEndingOffset(messageId);
         assertFalse("Should be false", result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1184,6 +1256,9 @@ public class VirtualSpoutTest {
         // Call our method & validate.
         final boolean result = virtualSpout.doesMessageExceedEndingOffset(messageId);
         assertTrue("Should be true", result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1227,6 +1302,9 @@ public class VirtualSpoutTest {
         // Call our method & validate.
         final boolean result = virtualSpout.doesMessageExceedEndingOffset(messageId);
         assertFalse("Should be false", result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     @Rule
@@ -1275,6 +1353,9 @@ public class VirtualSpoutTest {
         // Call our method & validate exception is thrown
         expectedExceptionDoesMessageExceedEndingOffsetForAnInvalidPartition.expect(IllegalStateException.class);
         virtualSpout.doesMessageExceedEndingOffset(messageId);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1319,6 +1400,9 @@ public class VirtualSpoutTest {
 
         // Validate mock call
         verify(mockConsumer, times(1)).unsubscribeConsumerPartition(eq(topicPartition));
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1473,16 +1557,12 @@ public class VirtualSpoutTest {
 
     /**
      * This test does the following:
-     *
-     * 1. Call nextTuple() -
-     *  a. the first time RetryManager should return null, saying it has no failed tuples to replay
-     *  b. consumer should return a consumer record, and it should be returned by nextTuple()
-     * 2. Call fail() with the message previously returned from nextTuple().
-     * 2. Call nextTuple()
-     *  a. This time RetryManager should return the failed tuple
-     * 3. Call nextTuple()
-     *  a. This time RetryManager should return null, saying it has no failed tuples to replay.
-     *  b. consumer should return a new consumer record.
+     *   Sets up a VirtualSpout with injected mock retry manager and consumer.
+     *   We instruct the mock consumer to return a Record when nextRecord() is called.
+     *   We ask VirtualSpout for nextTuple() and it should return us a Message wrapped around the record.
+     *   We call fail on this Message's MessageId.
+     *   We ask VirtualSpout for nextTuple() and it should return us the same message, but this time marked as permanently failed.
+     *   Also at this point it should be marked as acked.
      */
     @Test
     public void testCallingFailCallsAckOnWhenItShouldNotBeRetried() {
@@ -1494,11 +1574,11 @@ public class VirtualSpoutTest {
         final String expectedKey = "MyKey";
         final String expectedValue = "MyValue";
 
-        // Define expected result
-        final Message expectedMessage = new Message(
-            new MessageId(expectedTopic, expectedPartition, expectedOffset, expectedConsumerId),
-            new Values(expectedKey, expectedValue)
-        );
+        // Define expected values
+        final Values expectedValues = new Values(expectedKey, expectedValue);
+
+        // Define expected Record
+        final Record expectedRecord = new Record(expectedTopic, expectedPartition, expectedOffset, expectedValues);
 
         // Create test config
         final Map topologyConfig = getDefaultConfig();
@@ -1516,6 +1596,9 @@ public class VirtualSpoutTest {
         final FactoryManager mockFactoryManager = createMockFactoryManager(null, mockRetryManager, null, null);
         when(mockFactoryManager.createNewConsumerInstance()).thenReturn(mockConsumer);
 
+        // When the underlying consumer is asked for the next record, it should return our record
+        when(mockConsumer.nextRecord()).thenReturn(expectedRecord);
+
         // Create spout & open
         final VirtualSpout virtualSpout = new VirtualSpout(
             expectedConsumerId,
@@ -1528,10 +1611,16 @@ public class VirtualSpoutTest {
         );
         virtualSpout.open();
 
-        // Now call fail on this
-        final MessageId failedMessageId = expectedMessage.getMessageId();
+        // Ask for the next message, it should be our wrapped mockRecord.
+        final Message message = virtualSpout.nextTuple();
 
-        // Retry manager should retry this tuple.
+        // Verify its not permanently failed
+        assertFalse("Should not be permanently failed", message.isPermanentlyFailed());
+
+        // Grab messageId out
+        final MessageId failedMessageId = message.getMessageId();
+
+        // Retry manager should NOT retry this tuple.
         when(mockRetryManager.retryFurther(failedMessageId)).thenReturn(false);
 
         // call fail on our message id
@@ -1544,6 +1633,19 @@ public class VirtualSpoutTest {
             failedMessageId.getPartition(),
             failedMessageId.getOffset()
         );
+
+        // Calling nextMessage should give us the permanently failed message
+        final Message permanentlyFailedMessage = virtualSpout.nextTuple();
+        assertNotNull("Should be non-null", permanentlyFailedMessage);
+
+        // Should be the same messageId
+        assertEquals("Should have same messageId as previously", failedMessageId, permanentlyFailedMessage.getMessageId());
+
+        // Should be marked as permanently failed
+        assertTrue("Should be marked as permanently failed", permanentlyFailedMessage.isPermanentlyFailed());
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1594,6 +1696,9 @@ public class VirtualSpoutTest {
         // Verify result
         assertNotNull("result should not be null", result);
         assertEquals("Should be our expected instance", expectedConsumerState, result);
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1641,6 +1746,9 @@ public class VirtualSpoutTest {
             endingState,
             virtualSpout.getEndingState()
         );
+
+        // Call close
+        virtualSpout.close();
     }
 
     /**
@@ -1656,9 +1764,7 @@ public class VirtualSpoutTest {
         defaultConfig.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
 
         // DynamicSpout config items
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_ROOT, "/sideline-spout-test");
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList("localhost:21811"));
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
+        defaultConfig.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, InMemoryPersistenceAdapter.class.getName());
         defaultConfig.put(
             SidelineConfig.PERSISTENCE_ADAPTER_CLASS,
             com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.class.getName()

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -41,7 +41,6 @@ import com.salesforce.storm.spout.dynamic.consumer.ConsumerState;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Deserializer;
 import com.salesforce.storm.spout.dynamic.kafka.deserializer.Utf8StringDeserializer;
 import com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter;
-import com.salesforce.storm.spout.dynamic.persistence.ZookeeperPersistenceAdapter;
 import com.salesforce.storm.spout.dynamic.retry.NeverRetryManager;
 import com.salesforce.storm.spout.dynamic.retry.RetryManager;
 import com.salesforce.storm.spout.dynamic.metrics.LogRecorder;
@@ -272,7 +271,7 @@ public class VirtualSpoutTest {
             anyMap(),
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
-            any(ZookeeperPersistenceAdapter.class),
+            any(PersistenceAdapter.class),
             eq(metricsRecorder),
             eq(null)
         );
@@ -341,7 +340,7 @@ public class VirtualSpoutTest {
             anyMap(),
             eq(virtualSpoutIdentifier),
             any(ConsumerPeerContext.class),
-            any(ZookeeperPersistenceAdapter.class),
+            any(PersistenceAdapter.class),
             eq(metricsRecorder),
             eq(null)
         );


### PR DESCRIPTION
**Use Case**
We'd like the ability to handle tuples that are considered "permanently failed".  We're defining "permanently failed" meaning that the topology attempted to process the tuple at least once and the `RetryManager` implementation has determined that the tuple should never be retried.  When this occurs, the tuple will be emitted un-anchored out a "failed" stream.  Bolts within the topology can subscribe to this "failed" stream and do its own error handling.

It should be noted (again) that tuples emitted on the "failed" stream are un-anchored and should be considered unreliable.  IE. The spout will not track it or be notified of failed or acked tuples emitted down this "failed" stream.

**Notes**

One idea was to move the RetryFailedMessageManager out of the VirtualSpouts and only have a single instance living within DynamicSpout (instead of one per VSpout).  Doing so would simplify the logic around being able to easily identify and emit out permanently failed tuples.  The trade off is this alters how we enforce fairness across VirtualSpouts.  If we continue to give priority to failed tuples being replayed over new tuples means that a single VSpout emitting tons of tuples that end up failing could overwhelm the spout's output.

Instead I added an additional flag on the Message object that allows you to mark it as permanently failed, and DynamicSpout uses that flag to determine which stream to emit down.  Not entirely the most elegant solution, so open to other ideas.

Thoughts?

**Todo**
Update changelog & readme

