### PR TITLE
Catch and swallow no-node exceptions (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.9.2 (2017-12-13)
 ### Bug Fixes
-- [ISSUE-93](https://github.com/salesforce/storm-dynamic-spout/pull/93) Fix race condition while cleaning up consumer state.
+- [ISSUE-92](https://github.com/salesforce/storm-dynamic-spout/issues/92) Fix race condition while cleaning up consumer state.
 
 ## 0.9.1 (2017-12-05)
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [PR-86](https://github.com/salesforce/storm-dynamic-spout/pull/86) Sideline payload null checking
 - [PR-88](https://github.com/salesforce/storm-dynamic-spout/pull/88) Sideline payload null checking
 
+## 0.9.2 (2017-12-13)
+### Bug Fixes
+- [ISSUE-93](https://github.com/salesforce/storm-dynamic-spout/pull/93) Fix race condition while cleaning up consumer state.
+
 ## 0.9.1 (2017-12-05)
 ### Bug Fixes
 - [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId.

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.salesforce.storm</groupId>
     <artifactId>dynamic-spout</artifactId>
-    <!-- Last release was 0.9.1 on 2017-12-05 -->
+    <!-- Last release was 0.9.2 on 2017-12-14 -->
     <version>0.9.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dynamic-spout</name>

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelper.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelper.java
@@ -180,7 +180,13 @@ public class CuratorHelper {
                 logger.info("Removing empty path {}", path);
                 curator.delete().forPath(path);
             }
-        } catch (Exception e) {
+        } catch (final KeeperException.NoNodeException noNodeException) {
+            // We caught a no-node exception. That means the node we wanted to delete didn't exist.
+            // Well, that's more or less the end result we wanted right?  This happens because of a
+            // race conditions between checking if the node exists and actually removing it, some other client removed
+            // the node for us. For more information see https://github.com/salesforce/storm-dynamic-spout/issues/92
+            logger.info("Requested to remove zookeeper node {} but that node did not exist.", path);
+        } catch (final Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
@@ -29,9 +29,15 @@ import com.google.common.base.Charsets;
 import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.utils.SharedZookeeperTestResource;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.DeleteBuilder;
+import org.apache.curator.framework.api.ExistsBuilder;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +45,11 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Aims to provide integration testing over CuratorHelper and CuratorFactory against a 'live'
@@ -102,6 +113,123 @@ public class CuratorHelperTest {
             assertEquals("Has key 2", 2L, resultMap.get("key2"));
             assertEquals("Has key 3", true, resultMap.get("key3"));
         }
+    }
+
+    /**
+     * Tests that if we attempt to delete a node with children, it won't delete it.
+     */
+    @Test
+    public void testDeleteNodeIfNoChildren_hasChildrenShouldNotDelete() throws Exception {
+        final String basePath = "/testDeleteNodeIfNoChildren_hasChildrenShouldNotDelete";
+        final String childPath = basePath + "/childNode";
+
+        try (final CuratorFramework curator = createCurator()) {
+            // Create basePath
+            curator
+                .create()
+                .creatingParentsIfNeeded()
+                .forPath(basePath);
+
+            // Create some child nodes
+            curator
+                .create()
+                .forPath(childPath);
+
+            // Now create our helper
+            final CuratorHelper curatorHelper = new CuratorHelper(curator);
+
+            // Call our method
+            curatorHelper.deleteNodeIfNoChildren(basePath);
+
+            // Validate child nodes still exist
+            Stat result = curator
+                .checkExists()
+                .forPath(childPath);
+            assertNotNull("Child path should exist", result);
+
+            // Validate base exists
+            result = curator
+                .checkExists()
+                .forPath(basePath);
+            assertNotNull("base path should exist", result);
+            assertEquals("Should have 1 child", 1, result.getNumChildren());
+
+            // Cleanup
+            curator
+                .delete()
+                .deletingChildrenIfNeeded()
+                .forPath(basePath);
+
+            // Validate is gone, sanity check.
+            result = curator
+                .checkExists()
+                .forPath(basePath);
+            assertNull("base path should be removed", result);
+        }
+    }
+
+    /**
+     * Tests that if we attempt to delete a node without any children, it will delete it.
+     */
+    @Test
+    public void testDeleteNodeIfNoChildren_hasNoChildrenShouldDelete() throws Exception {
+        final String basePath = "/testDeleteNodeIfNoChildren_hasNoChildrenShouldDelete";
+
+        try (final CuratorFramework curator = createCurator()) {
+            // Create basePath
+            curator
+                .create()
+                .creatingParentsIfNeeded()
+                .forPath(basePath);
+
+            // Now create our helper
+            final CuratorHelper curatorHelper = new CuratorHelper(curator);
+
+            // Call our method
+            curatorHelper.deleteNodeIfNoChildren(basePath);
+
+            // Validate is gone
+            final Stat result = curator
+                .checkExists()
+                .forPath(basePath);
+            assertNull("base path should be removed", result);
+        }
+    }
+
+    /**
+     * Tests that if we attempt to delete a node that doesnt actually exist
+     * just silently returns.
+     *
+     * To simulate a race condition we do this using mocks.
+     */
+    @Test
+    public void testDeleteNodeIfNoChildren_withNodeThatDoesntExist() throws Exception {
+        final String basePath = "/testDeleteNodeIfNoChildren_withNodeThatDoesntExist";
+
+        final CuratorFramework mockCurator = mock(CuratorFramework.class);
+
+        // Exists builder should return true saying our basePath exists.
+        final ExistsBuilder mockExistsBuilder = mock(ExistsBuilder.class);
+        when(mockExistsBuilder.forPath(eq(basePath))).thenReturn(new Stat());
+        when(mockCurator.checkExists()).thenReturn(mockExistsBuilder);
+
+        // When we look for children, make sure it returns an empty list.
+        final GetChildrenBuilder mockGetChildrenBuilder = mock(GetChildrenBuilder.class);
+        when(mockGetChildrenBuilder.forPath(eq(basePath))).thenReturn(new ArrayList<>());
+        when(mockCurator.getChildren()).thenReturn(mockGetChildrenBuilder);
+
+        // When we go to delete the actual node, we toss a no-node exception.
+        // This effectively simulates a race condition between checking if the node exists (our mock above says yes)
+        // and it being removed before we call delete on it.
+        final DeleteBuilder mockDeleteBuilder = mock(DeleteBuilder.class);
+        when(mockDeleteBuilder.forPath(eq(basePath))).thenThrow(new KeeperException.NoNodeException());
+        when(mockCurator.delete()).thenReturn(mockDeleteBuilder);
+
+        // Now create our helper
+        final CuratorHelper curatorHelper = new CuratorHelper(mockCurator);
+
+        // Call our method
+        curatorHelper.deleteNodeIfNoChildren(basePath);
     }
 
     /**


### PR DESCRIPTION
Handle race condition between checking if a node exists, and removing the node.

Backporting bugfix to 0.9.x release: #92 

Cuts bugfix version 0.9.2