### PR TITLE
Remove references to sideline from DynamicSpout tests

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/DynamicSpout.java
@@ -260,6 +260,7 @@ public class DynamicSpout extends BaseRichSpout {
      * @param declarer The output field declarer
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void declareOutputFields(final OutputFieldsDeclarer declarer) {
         // Handles both explicitly defined and default stream definitions.
         final String streamId = getOutputStreamId();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/FactoryManager.java
@@ -151,7 +151,8 @@ public class FactoryManager implements Serializable {
         }
 
         try {
-            Class<? extends T> clazz = (Class<? extends T>) Class.forName(classStr);
+            @SuppressWarnings("unchecked")
+            final Class<? extends T> clazz = (Class<? extends T>) Class.forName(classStr);
             return clazz.newInstance();
         } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/coordinator/SpoutCoordinator.java
@@ -247,7 +247,7 @@ public class SpoutCoordinator implements Runnable {
             // Wait up to MaxTerminationTime for it to finish
             final long endTime = getClock().millis() + getMaxTerminationWaitTimeMs();
             do {
-                Thread.sleep(500L);
+                Thread.sleep(100L);
                 if (spoutContext.getCompletableFuture().isDone()) {
                     // If its done, we're done!
                     return;

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -429,16 +429,11 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
             );
 
             if (sidelinePayload == null) {
-                logger.warn("Sideline {} on partition {} payload was null, this is probably a serialization problem.");
+                logger.error("Attempting to load sideline {} for partition {} and it was null.", id, consumerPartition.partition());
                 continue;
             }
 
             logger.info("Loaded sideline payload for {} = {}", consumerPartition, sidelinePayload);
-
-            if (sidelinePayload == null) {
-                logger.error("Attempting to load sideline {} for partition {} and it was null.", id, consumerPartition.partition());
-                continue;
-            }
 
             if (sidelinePayload.startingOffset == null) {
                 logger.error("Loaded sideline {} for partition {} but the starting offset was null", id, consumerPartition.partition());

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -242,7 +242,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
 
                 for (final String partition : partitions) {
                     consumerPartitions.add(
-                        new ConsumerPartition(namespace, Integer.valueOf(partition))
+                        new ConsumerPartition(namespace, Integer.parseInt(partition))
                     );
                 }
             }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/ZookeeperWatchTrigger.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.storm.spout.sideline.trigger.example;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -165,7 +166,7 @@ public class ZookeeperWatchTrigger implements SidelineTrigger {
                     curator
                         .create()
                         .creatingParentsIfNeeded()
-                        .forPath(root, "".getBytes());
+                        .forPath(root, new byte[0]);
                 } else {
                     // Load the existing requests from it
                     final List<String> sidelineRequests = curator.getChildren().forPath(root);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/filter/FilterChainTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/filter/FilterChainTest.java
@@ -29,7 +29,6 @@ import com.salesforce.storm.spout.dynamic.Message;
 import com.salesforce.storm.spout.dynamic.MessageId;
 import com.salesforce.storm.spout.dynamic.DefaultVirtualSpoutIdentifier;
 import com.salesforce.storm.spout.dynamic.VirtualSpoutIdentifier;
-import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import org.apache.storm.tuple.Values;
 import org.junit.Test;
 
@@ -98,9 +97,9 @@ public class FilterChainTest {
         );
 
         final FilterChain filterChain = new FilterChain()
-            .addStep(new SidelineRequestIdentifier("1"), new NumberFilter(2))
-            .addStep(new SidelineRequestIdentifier("2"), new NumberFilter(4))
-            .addStep(new SidelineRequestIdentifier("3"), new NumberFilter(5))
+            .addStep(new DefaultFilterChainStepIdentifier("1"), new NumberFilter(2))
+            .addStep(new DefaultFilterChainStepIdentifier("2"), new NumberFilter(4))
+            .addStep(new DefaultFilterChainStepIdentifier("3"), new NumberFilter(5))
         ;
 
         assertTrue("Message 2 should be fitlered", filterChain.filter(message2));
@@ -129,7 +128,7 @@ public class FilterChainTest {
         );
 
         final FilterChain filterChain = new FilterChain()
-            .addStep(new SidelineRequestIdentifier("1"), new NegatingFilterChainStep(new NumberFilter(2)))
+            .addStep(new DefaultFilterChainStepIdentifier("1"), new NegatingFilterChainStep(new NumberFilter(2)))
         ;
 
         assertTrue("Message 1 should be filtered", filterChain.filter(message1));

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Validates that our SidelineConsumer works as we expect under various scenarios.
+ * Validates that our Kafka Consumer works as we expect under various scenarios.
  */
 @RunWith(DataProviderRunner.class)
 public class ConsumerTest {
@@ -1172,8 +1172,8 @@ public class ConsumerTest {
 
     /**
      * Produce 10 messages into a kafka topic: offsets [0-9]
-     * Setup our SidelineConsumer such that its pre-existing state says to start at offset 4
-     * Consume using the SidelineConsumer, verify we only get the last 5 messages back.
+     * Setup our Consumer such that its pre-existing state says to start at offset 4
+     * Consume using the Consumer, verify we only get the last 5 messages back.
      */
     @Test
     public void testConsumerWithInitialStateToSkipMessages() {
@@ -1344,7 +1344,7 @@ public class ConsumerTest {
     }
 
     /**
-     * This is an integration test of multiple SidelineConsumers.
+     * This is an integration test of multiple Consumers.
      * We stand up a topic with 4 partitions.
      * We then have a consumer size of 2.
      * We run the test once using consumerIndex 0
@@ -2510,7 +2510,7 @@ public class ConsumerTest {
         defaultConfig.put(KafkaConsumerConfig.DESERIALIZER_CLASS, Utf8StringDeserializer.class.getName());
 
         // Dynamic Spout config items
-        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_ROOT, "/sideline-spout-test");
+        defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_ROOT, "/dynamic-spout-test");
         defaultConfig.put(SpoutConfig.PERSISTENCE_ZK_SERVERS, Lists.newArrayList(getKafkaTestServer().getZookeeperConnectString()));
         defaultConfig.put(SpoutConfig.PERSISTENCE_ADAPTER_CLASS, ZookeeperPersistenceAdapter.class.getName());
 


### PR DESCRIPTION
Continue to work towards removing Sideline dependency out of DynamicSpout core package space.

Removes dependencies within tests to Sideline classes, but the tests themselves don't actually depend on any sideline logic.  So swapped them out with their Default implementations.