### PR TITLE
Switching test to use the in memory persistence adapters

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/InMemoryPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/InMemoryPersistenceAdapter.java
@@ -37,13 +37,13 @@ public class InMemoryPersistenceAdapter implements PersistenceAdapter {
     /**
      * In memory store for this adapter's data.
      */
-    public static Map<String, Long> storedConsumerState = Maps.newHashMap();
+    public static Map<String, Long> storedConsumerState = Maps.newConcurrentMap();
 
     /**
      * Reset the internal memory store.
      */
     public static void reset() {
-        storedConsumerState = Maps.newHashMap();
+        storedConsumerState = Maps.newConcurrentMap();
     }
 
     @Override

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/InMemoryPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/InMemoryPersistenceAdapter.java
@@ -48,13 +48,13 @@ public class InMemoryPersistenceAdapter implements PersistenceAdapter {
     /**
      * In memory store for this adapter's data.
      */
-    public static Map<SidelineRequestStateKey, SidelinePayload> storedSidelineRequests = Maps.newHashMap();
+    public static Map<SidelineRequestStateKey, SidelinePayload> storedSidelineRequests = Maps.newConcurrentMap();
 
     /**
      * Reset the internal memory store.
      */
     public static void reset() {
-        storedSidelineRequests = Maps.newHashMap();
+        storedSidelineRequests = Maps.newConcurrentMap();
     }
 
     @Override

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/InMemoryPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/InMemoryPersistenceAdapter.java
@@ -45,20 +45,24 @@ import java.util.Set;
  */
 public class InMemoryPersistenceAdapter implements PersistenceAdapter {
 
-    // "Persists" side line request states in memory.
-    private Map<SidelineRequestStateKey, SidelinePayload> storedSidelineRequests;
+    /**
+     * In memory store for this adapter's data.
+     */
+    public static Map<SidelineRequestStateKey, SidelinePayload> storedSidelineRequests = Maps.newHashMap();
+
+    /**
+     * Reset the internal memory store.
+     */
+    public static void reset() {
+        storedSidelineRequests = Maps.newHashMap();
+    }
 
     @Override
     public void open(Map spoutConfig) {
-        if (storedSidelineRequests == null) {
-            storedSidelineRequests = Maps.newHashMap();
-        }
     }
 
     @Override
     public void close() {
-        // Cleanup
-        storedSidelineRequests.clear();
     }
 
     @Override
@@ -110,19 +114,28 @@ public class InMemoryPersistenceAdapter implements PersistenceAdapter {
         return Collections.unmodifiableSet(partitions);
     }
 
-    private SidelineRequestStateKey getSidelineRequestStateKey(
+    /**
+     * Generate the key used for the in memory store.  Use this if you need to manipulate the store outside of the normal flow.
+     * @param id sideline request id.
+     * @param consumerPartition consumer partition.
+     * @return key for the in memory store.
+     */
+    public static SidelineRequestStateKey getSidelineRequestStateKey(
         final SidelineRequestIdentifier id,
         final ConsumerPartition consumerPartition
     ) {
         return new SidelineRequestStateKey(id, consumerPartition);
     }
 
-    private static class SidelineRequestStateKey {
+    /**
+     * Object used for keying the memory store.
+     */
+    public static class SidelineRequestStateKey {
 
         public final SidelineRequestIdentifier id;
         public final ConsumerPartition consumerPartition;
 
-        SidelineRequestStateKey(final SidelineRequestIdentifier id, final ConsumerPartition consumerPartition) {
+        private SidelineRequestStateKey(final SidelineRequestIdentifier id, final ConsumerPartition consumerPartition) {
             this.id = id;
             this.consumerPartition = consumerPartition;
         }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/example/TriggerEvent.java
@@ -53,8 +53,8 @@ public class TriggerEvent {
     private LocalDateTime updatedAt;
 
     /**
-     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of sideline state
-     * for the system.
+     * An event to a {@link com.salesforce.storm.spout.sideline.trigger.SidelineTrigger} that communicates the desired type of
+     * sideline state for the system.
      *
      * When you create a TriggerEvent in Zookeeper always set processed = false, the trigger implementation will flip this to true
      * after it has been picked up and handled by the trigger. This allows you to distinguish an event that's been handled by the

--- a/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/kafka/ConsumerTest.java
@@ -128,6 +128,10 @@ public class ConsumerTest {
 
         // Create namespace
         getKafkaTestServer().createTopic(topicName);
+
+        // We are testing functionality with subsequent open() calls and we don't want our in memory persistence to clear out on close()
+        com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.reset();
+        com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.reset();
     }
 
     /**

--- a/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/mocks/MockConsumer.java
@@ -53,7 +53,6 @@ public class MockConsumer implements Consumer {
     public static String topic = "MyTopic";
     public static List<Integer> partitions = Collections.singletonList(1);
 
-    private PersistenceAdapter persistenceAdapter;
     private VirtualSpoutIdentifier activeVirtualSpoutIdentifier;
 
     @Override
@@ -65,7 +64,6 @@ public class MockConsumer implements Consumer {
         MetricsRecorder metricsRecorder,
         ConsumerState startingState
     ) {
-        this.persistenceAdapter = persistenceAdapter;
         this.activeVirtualSpoutIdentifier = virtualSpoutIdentifier;
 
         // Create empty queue.
@@ -153,7 +151,8 @@ public class MockConsumer implements Consumer {
      */
     public static void injectRecords(
         final VirtualSpoutIdentifier virtualSpoutIdentifier,
-        final Collection<Record> injectedRecords) {
+        final Collection<Record> injectedRecords
+    ) {
         synchronized (MockConsumer.class) {
             if (!recordHolder.containsKey(virtualSpoutIdentifier)) {
                 recordHolder.put(virtualSpoutIdentifier, new LinkedBlockingQueue<>(10_000));

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -51,6 +51,7 @@ import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import com.salesforce.storm.spout.sideline.trigger.SidelineType;
 import com.salesforce.storm.spout.sideline.trigger.StaticTrigger;
 import org.apache.storm.task.TopologyContext;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -75,6 +76,16 @@ import static org.junit.Assert.assertTrue;
 public class SidelineSpoutHandlerTest {
 
     private static String CONSUMER_ID_PREFIX = "VirtualSpoutPrefix";
+
+    /**
+     * Before we run that test...
+     */
+    @Before
+    public void beforeTest() {
+        // We are testing functionality with subsequent open() calls and we don't want our in memory persistence to clear out on close()
+        com.salesforce.storm.spout.dynamic.persistence.InMemoryPersistenceAdapter.reset();
+        com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter.reset();
+    }
 
     /**
      * Test the open method properly stores the spout's config.


### PR DESCRIPTION
This is an attempt to decouple the `SidelineSpoutTest` from Zookeeper.