### PR TITLE
Do not pass empty ending state when loading sidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ In this release the 'stop' sideline state was split into 'resume' and 'resolve',
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added `is*()` methods to the `SidelineController` for the respective sideline states.
 - [PR-47](https://github.com/salesforce/storm-dynamic-spout/pull/47) Sidelining periodically checks to ensure `VirtualSpout` instances are running and have the proper `FilterChainStep` objects applied to them.
 - [PR-97](https://github.com/salesforce/storm-dynamic-spout/pull/97) Sideline config defaults are now set properly.
+- [PR-99](https://github.com/salesforce/storm-dynamic-spout/pull/99) Do not pass empty ending state when loading sidelines.
 
 ### Kafka Consumer
 #### Removed

--- a/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandler.java
@@ -297,12 +297,16 @@ public class SidelineSpoutHandler implements SpoutHandler, SidelineController {
             if (payload.type.equals(SidelineType.RESUME) || payload.type.equals(SidelineType.RESOLVE)) {
                 logger.info("Handling {} request for sideline {} {}", payload.type, payload.id, payload.request.step);
 
+                final ConsumerState startingState = startingStateBuilder.build();
+                final ConsumerState endingState = endingStateStateBuilder.build();
+
                 // This method will check to see that the VirtualSpout isn't already in the SpoutCoordinator before adding it
                 addSidelineVirtualSpout(
                     payload.id,
                     payload.request.step,
-                    startingStateBuilder.build(),
-                    endingStateStateBuilder.build()
+                    startingState,
+                    // Only pass ending state if it's not empty
+                    endingState.isEmpty() ? null : endingStateStateBuilder.build()
                 );
             }
         }

--- a/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/handler/SidelineSpoutHandlerTest.java
@@ -355,6 +355,8 @@ public class SidelineSpoutHandlerTest {
             sidelineVirtualSpout.getFilterChain().getStep(requestId)
         );
 
+        assertNull("Ending state should be null", sidelineVirtualSpout.getEndingState());
+
         final SidelinePayload sidelinePayload = persistenceAdapter.retrieveSidelineRequest(
             requestId,
             new ConsumerPartition(namespace, partitionId)


### PR DESCRIPTION
When redeploying a topology with an existing sideline in the resume state I noticed the sideline failed to load because of the exception thrown at https://github.com/salesforce/storm-dynamic-spout/blob/2dc9dbd394b81ed7516068b32c9b58589d3729a7/src/main/java/com/salesforce/storm/spout/dynamic/VirtualSpout.java#L347-L353

This is because there is no ending state set in the resume, but we instantiate the builder regardless and never populate it. To avoid this exception I added a check to make sure that the ending state is empty, and if it is to pass null on instead.