### PR TITLE
[ISSUE-100] - Fix NPE in RatioMessageBuffer on spout deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and adhere
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing `FilterChainStep` objects. 
 - [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId.
 - [PR-90](https://github.com/salesforce/storm-dynamic-spout/pull/90) Adds new 'Permanently Failed' output stream.  Tuples that exceed the configured retry limit will now be emitted out a 'failed' stream un-anchored. This allows you to do your own error handling within the topology by subscribing to this stream. The name of this output stream defaults to 'failed', but is configurable via the `spout.permanently_failed_output_stream_id` configuration item.
+- [ISSUE-100](https://github.com/salesforce/storm-dynamic-spout/issues/100) Fix NPE in RatioMessageBuffer on Spout deploy.
 
 #### Removed
 - [PR-45](https://github.com/salesforce/storm-dynamic-spout/pull/45) Removed getMaxLag() from Consumer interface.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/buffer/RatioMessageBuffer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/buffer/RatioMessageBuffer.java
@@ -278,6 +278,9 @@ public class RatioMessageBuffer implements MessageBuffer {
         return nextVirtualSpoutIdGenerator.getAllNonThrottledVirtualSpoutIds();
     }
 
+    /**
+     * Internal helper class for determining which VirtualSpoutId is up to be consumed from next.
+     */
     private static class NextVirtualSpoutIdGenerator {
         private final int ratio;
         private final List<VirtualSpoutIdentifier> order = new ArrayList<>();
@@ -296,6 +299,11 @@ public class RatioMessageBuffer implements MessageBuffer {
             this.ratio = ratio;
         }
 
+        /**
+         * Notify instance of a new VirtualSpoutIdentifier.
+         * @param identifier VirtualSpoutIdentifier to be added.
+         * @param isThrottled True if the virtual spout should be considered throttled.
+         */
         void addNewVirtualSpout(final VirtualSpoutIdentifier identifier, final boolean isThrottled) {
             if (!allIds.containsKey(identifier)) {
                 allIds.put(identifier, isThrottled);
@@ -303,6 +311,10 @@ public class RatioMessageBuffer implements MessageBuffer {
             }
         }
 
+        /**
+         * Notify instance of a VirtualSpoutIdentifier being removed.
+         * @param identifier VirtualSpoutIdentifier to be removed.
+         */
         void removeVirtualSpout(final VirtualSpoutIdentifier identifier) {
             if (allIds.containsKey(identifier)) {
                 allIds.remove(identifier);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/buffer/RatioMessageBufferTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/buffer/RatioMessageBufferTest.java
@@ -105,6 +105,20 @@ public class RatioMessageBufferTest {
     }
 
     /**
+     * Validate that if you call poll when no virtualspouts are registered, things behave.
+     */
+    @Test
+    public void testPollWithNoVirtualSpouts() {
+        final String regexPattern = "^Throttled.*";
+
+        // Create instance & open
+        final RatioMessageBuffer buffer = createDefaultBuffer(10, 3, regexPattern);
+
+        // Call poll, should get null.
+        assertNull("Should be null return value", buffer.poll());
+    }
+
+    /**
      * Tests that we return messages from the poll() method based on configured ratio
      * with two VirtualSpouts -- 1 throttled and 1 not throttled.
      */
@@ -115,7 +129,7 @@ public class RatioMessageBufferTest {
         final String regexPattern = "^Throttled.*";
 
         // Create instance & open
-        RatioMessageBuffer buffer = createDefaultBuffer(bufferSize, throttleRatio, regexPattern);
+        final RatioMessageBuffer buffer = createDefaultBuffer(bufferSize, throttleRatio, regexPattern);
 
         // Create 2 VSpout Ids
         VirtualSpoutIdentifier virtualSpoutId1 = new DefaultVirtualSpoutIdentifier("Identifier1");


### PR DESCRIPTION
Bugfix for #100 

This code would previously NPE on Spout deploy because at deploy time there are no VirtualSpouts to be iterated over.