### PR TITLE
Change the default retry delay to have exponential growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and adhere
 - [PR-37](https://github.com/salesforce/storm-dynamic-spout/pull/37) Added hasStep() and getStep() to `FilterChain` and added a specific exception for serializing/deserializing `FilterChainStep` objects. 
 - [PR-85](https://github.com/salesforce/storm-dynamic-spout/pull/85) Fix ordering bug in DefaultRetryManager. Always retry the earliest messageId.
 - [PR-90](https://github.com/salesforce/storm-dynamic-spout/pull/90) Adds new 'Permanently Failed' output stream.  Tuples that exceed the configured retry limit will now be emitted out a 'failed' stream un-anchored. This allows you to do your own error handling within the topology by subscribing to this stream. The name of this output stream defaults to 'failed', but is configurable via the `spout.permanently_failed_output_stream_id` configuration item.
+- [PR-110](https://github.com/salesforce/storm-dynamic-spout/pull/110) Fix exponential retry delay growth in DefaultRetryManager.
 - [ISSUE-100](https://github.com/salesforce/storm-dynamic-spout/issues/100) Fix NPE in RatioMessageBuffer on Spout deploy.
 
 #### Removed

--- a/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
@@ -121,7 +121,7 @@ public class DefaultRetryManager implements RetryManager {
 
         // Determine when we should retry this msg next
         // Calculate how many milliseconds to wait until the next retry
-        long additionalTime = (long) (getInitialRetryDelayMs() * Math.pow(getRetryDelayMultiplier(), failCount));
+        long additionalTime = (long) (getInitialRetryDelayMs() * Math.pow(getRetryDelayMultiplier(), failCount - 1));
         if (additionalTime > getRetryDelayMaxMs()) {
             // If its over our configured max delay, use max delay
             additionalTime = getRetryDelayMaxMs();

--- a/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManager.java
@@ -121,7 +121,7 @@ public class DefaultRetryManager implements RetryManager {
 
         // Determine when we should retry this msg next
         // Calculate how many milliseconds to wait until the next retry
-        long additionalTime = (long) (failCount * getInitialRetryDelayMs() * getRetryDelayMultiplier());
+        long additionalTime = (long) (getInitialRetryDelayMs() * Math.pow(getRetryDelayMultiplier(), failCount));
         if (additionalTime > getRetryDelayMaxMs()) {
             // If its over our configured max delay, use max delay
             additionalTime = getRetryDelayMaxMs();

--- a/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Queue;
 
@@ -541,7 +542,7 @@ public class DefaultRetryManagerTest {
         retryManager.setClock(
             Clock.fixed(
             Instant.ofEpochMilli(FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0))),
-            ZoneId.of("UTC")
+            ZoneOffset.UTC
         ));
 
         // Now messageId1 should expire next,
@@ -559,7 +560,7 @@ public class DefaultRetryManagerTest {
         assertNull("Should be null", retryManager.nextFailedMessageToRetry());
         assertNull("Should be null", retryManager.nextFailedMessageToRetry());
 
-        // Advance time again, by 2x expected retry time, plus a few MS
+        // Advance time again, by expected retry time, plus a few MS
         final long newFixedTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1)) + 10;
         retryManager.setClock(Clock.fixed(Instant.ofEpochMilli(newFixedTime), ZoneId.of("UTC")));
 
@@ -576,7 +577,7 @@ public class DefaultRetryManagerTest {
         validateTupleIsNotBeingTracked(retryManager, messageId1);
         validateTupleNotInFailedSetButIsInFlight(retryManager, messageId2);
 
-        // Calculate time for 3rd fail, against new fixed time
+        // Calculate retry time for 3rd fail against new fixed time
         final long thirdRetryTime = newFixedTime + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
 
         // Mark tuple2 as having failed

--- a/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
@@ -540,10 +540,9 @@ public class DefaultRetryManagerTest {
         // Now advance time by exactly expectedMinRetryTimeMs milliseconds
         retryManager.setClock(
             Clock.fixed(
-                Instant.ofEpochMilli(FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0))),
-                ZoneId.of("UTC")
-            )
-        );
+            Instant.ofEpochMilli(FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0))),
+            ZoneId.of("UTC")
+        ));
 
         // Now messageId1 should expire next,
         MessageId nextMessageIdToBeRetried = retryManager.nextFailedMessageToRetry();

--- a/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
@@ -125,7 +125,7 @@ public class DefaultRetryManagerTest {
         retryManager.open(stormConfig);
 
         // Calculate the 1st retry times
-        final long firstRetryTime = FIXED_TIME + (long) (1 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0));
 
         final DefaultVirtualSpoutIdentifier consumerId = new DefaultVirtualSpoutIdentifier("MyConsumerId");
 
@@ -183,9 +183,9 @@ public class DefaultRetryManagerTest {
         final MessageId messageId2 = new MessageId("MyTopic", 0, 102L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
-        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
-        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
 
         // Mark first as having failed
         retryManager.failed(messageId1);
@@ -232,7 +232,7 @@ public class DefaultRetryManagerTest {
         final long expectedMinRetryTimeMs = 1000;
 
         // Use a multiplier of 10
-        final double expectedDelayMultiplier = 3;
+        final double expectedDelayMultiplier = 10;
 
         // Set a max delay of 12 seconds
         final long expectedMaxDelay = 12000;
@@ -251,8 +251,8 @@ public class DefaultRetryManagerTest {
         final MessageId messageId1 = new MessageId("MyTopic", 0, 101L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
-        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0)); // 1 second
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1)); // 10 seconds
         final long thirdRetryTime = FIXED_TIME + expectedMaxDelay;
 
         // Mark first as having failed
@@ -393,9 +393,9 @@ public class DefaultRetryManagerTest {
         final MessageId messageId2 = new MessageId("MyTopic", 0, 102L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
-        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
-        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
 
         // Mark first as having failed
         retryManager.failed(messageId1);
@@ -472,14 +472,14 @@ public class DefaultRetryManagerTest {
             retryManager,
             messageId1,
             1,
-            (FIXED_TIME + (long) (expectedMinRetryTimeMs * expectedDelayMultiplier)),
+            (FIXED_TIME + (long) expectedMinRetryTimeMs),
             false
         );
         validateExpectedFailedMessageId(
             retryManager,
             messageId2,
             1,
-            (FIXED_TIME + (long) (expectedMinRetryTimeMs * expectedDelayMultiplier)),
+            (FIXED_TIME + (long) expectedMinRetryTimeMs),
             false
         );
 
@@ -524,8 +524,8 @@ public class DefaultRetryManagerTest {
         retryManager.failed(messageId2);
 
         // Calculate the first and 2nd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
-        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
 
         // Validate it has first two as failed
         validateExpectedFailedMessageId(retryManager, messageId1, 1, firstRetryTime, false);
@@ -539,7 +539,10 @@ public class DefaultRetryManagerTest {
 
         // Now advance time by exactly expectedMinRetryTimeMs milliseconds
         retryManager.setClock(
-            Clock.fixed(Instant.ofEpochMilli(FIXED_TIME + (long) (expectedMinRetryTimeMs * expectedDelayMultiplier)), ZoneId.of("UTC"))
+            Clock.fixed(
+                Instant.ofEpochMilli(FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 0))),
+                ZoneId.of("UTC")
+            )
         );
 
         // Now messageId1 should expire next,
@@ -558,7 +561,7 @@ public class DefaultRetryManagerTest {
         assertNull("Should be null", retryManager.nextFailedMessageToRetry());
 
         // Advance time again, by 2x expected retry time, plus a few MS
-        final long newFixedTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier,2)) + 10;
+        final long newFixedTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1)) + 10;
         retryManager.setClock(Clock.fixed(Instant.ofEpochMilli(newFixedTime), ZoneId.of("UTC")));
 
         // Now messageId1 should expire next,
@@ -575,7 +578,7 @@ public class DefaultRetryManagerTest {
         validateTupleNotInFailedSetButIsInFlight(retryManager, messageId2);
 
         // Calculate time for 3rd fail, against new fixed time
-        final long thirdRetryTime = newFixedTime + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
+        final long thirdRetryTime = newFixedTime + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
 
         // Mark tuple2 as having failed
         retryManager.failed(messageId2);

--- a/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/retry/DefaultRetryManagerTest.java
@@ -166,7 +166,7 @@ public class DefaultRetryManagerTest {
         final long expectedMinRetryTimeMs = 1000;
 
         // Use a wacky multiplier, because why not?
-        final double expectedDelayMultiplier = 11.25;
+        final double expectedDelayMultiplier = 7.25;
 
         // Build config.
         Map stormConfig = getDefaultConfig(expectedMaxRetries, expectedMinRetryTimeMs, expectedDelayMultiplier, null);
@@ -183,9 +183,9 @@ public class DefaultRetryManagerTest {
         final MessageId messageId2 = new MessageId("MyTopic", 0, 102L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (1 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long secondRetryTime = FIXED_TIME + (long) (2 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long thirdRetryTime = FIXED_TIME + (long) (3 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
+        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
 
         // Mark first as having failed
         retryManager.failed(messageId1);
@@ -232,7 +232,7 @@ public class DefaultRetryManagerTest {
         final long expectedMinRetryTimeMs = 1000;
 
         // Use a multiplier of 10
-        final double expectedDelayMultiplier = 5;
+        final double expectedDelayMultiplier = 3;
 
         // Set a max delay of 12 seconds
         final long expectedMaxDelay = 12000;
@@ -251,8 +251,8 @@ public class DefaultRetryManagerTest {
         final MessageId messageId1 = new MessageId("MyTopic", 0, 101L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (1 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long secondRetryTime = FIXED_TIME + (long) (2 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
         final long thirdRetryTime = FIXED_TIME + expectedMaxDelay;
 
         // Mark first as having failed
@@ -393,9 +393,9 @@ public class DefaultRetryManagerTest {
         final MessageId messageId2 = new MessageId("MyTopic", 0, 102L, consumerId);
 
         // Calculate the 1st, 2nd, and 3rd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (1 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long secondRetryTime = FIXED_TIME + (long) (2 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long thirdRetryTime = FIXED_TIME + (long) (3 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
+        final long thirdRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
 
         // Mark first as having failed
         retryManager.failed(messageId1);
@@ -524,8 +524,8 @@ public class DefaultRetryManagerTest {
         retryManager.failed(messageId2);
 
         // Calculate the first and 2nd fail retry times
-        final long firstRetryTime = FIXED_TIME + (long) (1 * expectedMinRetryTimeMs * expectedDelayMultiplier);
-        final long secondRetryTime = FIXED_TIME + (long) (2 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long firstRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 1));
+        final long secondRetryTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 2));
 
         // Validate it has first two as failed
         validateExpectedFailedMessageId(retryManager, messageId1, 1, firstRetryTime, false);
@@ -558,7 +558,7 @@ public class DefaultRetryManagerTest {
         assertNull("Should be null", retryManager.nextFailedMessageToRetry());
 
         // Advance time again, by 2x expected retry time, plus a few MS
-        final long newFixedTime = FIXED_TIME + (long) (2 * expectedMinRetryTimeMs * expectedDelayMultiplier) + 10;
+        final long newFixedTime = FIXED_TIME + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier,2)) + 10;
         retryManager.setClock(Clock.fixed(Instant.ofEpochMilli(newFixedTime), ZoneId.of("UTC")));
 
         // Now messageId1 should expire next,
@@ -575,7 +575,7 @@ public class DefaultRetryManagerTest {
         validateTupleNotInFailedSetButIsInFlight(retryManager, messageId2);
 
         // Calculate time for 3rd fail, against new fixed time
-        final long thirdRetryTime = newFixedTime + (long) (3 * expectedMinRetryTimeMs * expectedDelayMultiplier);
+        final long thirdRetryTime = newFixedTime + (long) (expectedMinRetryTimeMs * Math.pow(expectedDelayMultiplier, 3));
 
         // Mark tuple2 as having failed
         retryManager.failed(messageId2);


### PR DESCRIPTION
While debugging retries, I noticed that the current retry behavior follows linear growth (2, 4, 6, 8 seconds). However, the comments on the DefaultRetryManager class and retry variables imply expontential growth (2, 4, 8, 16, etc.).

This fixes the retry code to grow exponentially as expected.