### PR TITLE
Rename examples to recipes

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/FilterChainStepBuilder.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/FilterChainStepBuilder.java
@@ -23,7 +23,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.sideline.trigger.example;
+package com.salesforce.storm.spout.sideline.recipes.trigger;
 
 import com.salesforce.storm.spout.dynamic.filter.FilterChainStep;
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/TriggerEvent.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/TriggerEvent.java
@@ -23,7 +23,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.sideline.trigger.example;
+package com.salesforce.storm.spout.sideline.recipes.trigger;
 
 import com.google.common.base.Preconditions;
 import com.salesforce.storm.spout.sideline.trigger.SidelineType;

--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
@@ -23,9 +23,10 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.sideline.trigger.example;
+package com.salesforce.storm.spout.sideline.recipes.trigger.zookeeper;
 
 import com.salesforce.storm.spout.documentation.ConfigDocumentation;
+import com.salesforce.storm.spout.sideline.recipes.trigger.FilterChainStepBuilder;
 
 import java.util.List;
 

--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTrigger.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTrigger.java
@@ -23,7 +23,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.sideline.trigger.example;
+package com.salesforce.storm.spout.sideline.recipes.trigger.zookeeper;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -34,6 +34,8 @@ import com.salesforce.storm.spout.dynamic.filter.FilterChainStep;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorFactory;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorHelper;
 import com.salesforce.storm.spout.sideline.handler.SidelineController;
+import com.salesforce.storm.spout.sideline.recipes.trigger.FilterChainStepBuilder;
+import com.salesforce.storm.spout.sideline.recipes.trigger.TriggerEvent;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequestIdentifier;
 import com.salesforce.storm.spout.sideline.trigger.SidelineTrigger;

--- a/src/test/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTriggerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTriggerTest.java
@@ -23,7 +23,7 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.storm.spout.sideline.trigger.example;
+package com.salesforce.storm.spout.sideline.recipes.trigger.zookeeper;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -38,6 +38,8 @@ import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorHelper;
 import com.salesforce.storm.spout.sideline.config.SidelineConfig;
 import com.salesforce.storm.spout.sideline.handler.SidelineSpoutHandler;
 import com.salesforce.storm.spout.sideline.persistence.InMemoryPersistenceAdapter;
+import com.salesforce.storm.spout.sideline.recipes.trigger.FilterChainStepBuilder;
+import com.salesforce.storm.spout.sideline.recipes.trigger.TriggerEvent;
 import com.salesforce.storm.spout.sideline.trigger.SidelineRequest;
 import com.salesforce.storm.spout.sideline.trigger.SidelineType;
 import org.apache.curator.framework.CuratorFramework;


### PR DESCRIPTION
These classes are intended for actual use. The nomenclature of 'recipes' seems to be more common for this sort of thing. Furthermore, I'm concerned people might think 'examples' are not intended for actual use. Thus I'm renaming this package, and I am also moving the common classes one level up so that we can do future implementation with them (eg. redis).