### PR TITLE
Metrics Refactoring

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilder.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.metrics;
+
+import org.slf4j.helpers.MessageFormatter;
+
+/**
+ * Takes a {@link MetricDefinition} and generates a String that can be used as a metric key.
+ */
+class KeyBuilder {
+
+    private final String keyPrefix;
+
+    /**
+     * Create a new {@link KeyBuilder} with the specified prefix.
+     *
+     * Prefix is optional, if you don't need it simply pass in null to the builder.
+     *
+     * @param keyPrefix prefix to use when building keys from {@link MetricDefinition} instances
+     */
+    KeyBuilder(final String keyPrefix) {
+        this.keyPrefix = keyPrefix;
+    }
+
+    /**
+     * Build metric keys from {@link MetricDefinition} instances with the optionally supplied parameters.
+     *
+     * Strings are formatted using {@link MessageFormatter}, so if you have parameters "foo" and "bar" for a metric with the name of "test"
+     * than you could use a {@link CustomMetric} with "test.{}.{}" in the constructor and pass parameters "foo" and "bar" to make the full
+     * metric key of "test.foo.bar".
+     *
+     * @return format string like: "prefix.metric_name.param1.param2"
+     */
+    String build(final MetricDefinition metric, final Object[] parameters) {
+        final StringBuilder keyBuilder = new StringBuilder();
+
+        // Conditionally add key prefix.
+        if (getKeyPrefix() != null && !getKeyPrefix().isEmpty()) {
+            keyBuilder
+                .append(getKeyPrefix())
+                .append(".");
+        }
+
+        // Our default implementation should include the simple class name in the key
+        keyBuilder.append(
+            MessageFormatter.arrayFormat(metric.getKey(), parameters).getMessage()
+        );
+        return keyBuilder.toString();
+    }
+
+    /**
+     * Get key prefix.
+     * @return key prefix
+     */
+    private String getKeyPrefix() {
+        return keyPrefix;
+    }
+}

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/LogRecorder.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/LogRecorder.java
@@ -42,6 +42,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LogRecorder implements MetricsRecorder {
 
     private static final Logger logger = LoggerFactory.getLogger(LogRecorder.class);
+
+    private final KeyBuilder keyBuilder = new KeyBuilder(null);
+
     private final Map<String, Long> counters = new ConcurrentHashMap<>();
     private final Map<String, Object> assignedValues = new ConcurrentHashMap<>();
 
@@ -134,6 +137,6 @@ public class LogRecorder implements MetricsRecorder {
     }
 
     private String generateKey(final MetricDefinition metric, final Object[] parameters) {
-        return MessageFormatter.format(metric.getKey(), parameters).getMessage();
+        return keyBuilder.build(metric, parameters);
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/LogRecorder.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/LogRecorder.java
@@ -25,6 +25,7 @@
 
 package com.salesforce.storm.spout.dynamic.metrics;
 
+import org.apache.storm.task.TopologyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,12 @@ public class LogRecorder implements MetricsRecorder {
     private final Map<String, Long> counters = new ConcurrentHashMap<>();
     private final Map<String, Object> assignedValues = new ConcurrentHashMap<>();
 
-    private final TimerManager timerManager = new TimerManager();
+    private TimerManager timerManager;
+
+    @Override
+    public void open(final Map<String, Object> config, final TopologyContext topologyContext) {
+        timerManager = new TimerManager();
+    }
 
     @Override
     public void countBy(final MetricDefinition metric, final long incrementBy, final Object... metricParameters) {

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/MetricsRecorder.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/MetricsRecorder.java
@@ -42,18 +42,22 @@ public interface MetricsRecorder {
      * @param spoutConfig spout configuration.
      * @param topologyContext topology context.
      */
-    void open(final Map<String, Object> spoutConfig, final TopologyContext topologyContext);
+    default void open(final Map<String, Object> spoutConfig, final TopologyContext topologyContext) {
+    }
 
     /**
      * Perform any cleanup.
      */
-    void close();
+    default void close() {
+    }
 
     /**
      * Count a metric, given a name, increments it by 1.
      * @param metric metric definition.
      */
-    void count(final MetricDefinition metric);
+    default void count(final MetricDefinition metric) {
+        countBy(metric, 1L, new Object[0]);
+    }
 
     /**
      * Count a metric, given a name, increments it by 1.
@@ -61,14 +65,18 @@ public interface MetricsRecorder {
      * @param metricParameters when a {@link MetricDefinition} supports interpolation on it's key, for example "foo.{}.bar" the {}
      *                         can be replace with the supplied parameters.
      */
-    void count(final MetricDefinition metric, final Object... metricParameters);
+    default void count(final MetricDefinition metric, final Object... metricParameters) {
+        countBy(metric, 1L, metricParameters);
+    }
 
     /**
      * Count a metric, given a name, increments it by value.
      * @param metric metric definition.
      * @param incrementBy amount to increment the metric by.
      */
-    void countBy(final MetricDefinition metric, final long incrementBy);
+    default void countBy(final MetricDefinition metric, final long incrementBy) {
+        countBy(metric, incrementBy, new Object[0]);
+    }
 
     /**
      * Count a metric, given a name and increments by a specific amount.
@@ -93,7 +101,9 @@ public interface MetricsRecorder {
      * @param metric metric definition.
      * @param value value to be assigned.
      */
-    void assignValue(final MetricDefinition metric, final Object value);
+    default void assignValue(final MetricDefinition metric, final Object value) {
+        assignValue(metric, value, new Object[0]);
+    }
 
     /**
      * Starts a timer for the given sourceClass and metricName.
@@ -107,7 +117,9 @@ public interface MetricsRecorder {
      * Starts a timer for the given sourceClass and metricName.
      * @param metric metric definition.
      */
-    void startTimer(final MetricDefinition metric);
+    default void startTimer(final MetricDefinition metric) {
+        startTimer(metric, new Object[0]);
+    }
 
     /**
      * Stops and records a timer for the given sourceClass and metricName.
@@ -123,7 +135,9 @@ public interface MetricsRecorder {
      * @param metric metric definition.
      * @return How long elapsed in the timer, in milliseconds.
      */
-    long stopTimer(final MetricDefinition metric);
+    default long stopTimer(final MetricDefinition metric) {
+        return stopTimer(metric, new Object[0]);
+    }
 
     /**
      * Record a timer passing in the elapsed time.

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/StormRecorder.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/StormRecorder.java
@@ -32,7 +32,6 @@ import org.apache.storm.metric.api.MultiReducedMetric;
 import org.apache.storm.task.TopologyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.MessageFormatter;
 
 import java.time.Clock;
 import java.util.Map;
@@ -55,6 +54,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class StormRecorder implements MetricsRecorder {
     private static final Logger logger = LoggerFactory.getLogger(StormRecorder.class);
+
+    private KeyBuilder keyBuilder;
 
     /**
      * Contains a map of Assigned Metrics, which are used to set a metric to a specific value.
@@ -102,6 +103,8 @@ public class StormRecorder implements MetricsRecorder {
                 this.metricPrefix = "task-" + topologyContext.getThisTaskIndex();
             }
         }
+
+        this.keyBuilder = new KeyBuilder(this.metricPrefix);
 
         // Log how we got configured.
         logger.info("Configured with time window of {} seconds and using taskId prefixes?: {}",
@@ -214,20 +217,7 @@ public class StormRecorder implements MetricsRecorder {
      * @return in format of: "className.metricPrefix.metricName"
      */
     private String generateKey(final MetricDefinition metric, final Object[] parameters) {
-        final StringBuilder keyBuilder = new StringBuilder();
-
-        // Conditionally add key prefix.
-        if (getMetricPrefix() != null && !getMetricPrefix().isEmpty()) {
-            keyBuilder
-                .append(getMetricPrefix())
-                .append(".");
-        }
-
-        // Our default implementation should include the simple class name in the key
-        keyBuilder.append(
-            MessageFormatter.format(metric.getKey(), parameters).getMessage()
-        );
-        return keyBuilder.toString();
+        return keyBuilder.build(metric, parameters);
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
@@ -72,6 +72,11 @@ class TimerManager {
      * @param startMs time in millis to set as the start
      */
     void start(final String key, final long startMs) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Timer key cannot be null or empty."
+            );
+        }
         if (startValuesMs.containsKey(key)) {
             throw new IllegalStateException(
                 MessageFormatter.format("The timer key {} already exists in this instances of {}", key, getClass()).getMessage()
@@ -88,6 +93,11 @@ class TimerManager {
      * @return time elapsed in millis
      */
     long stop(final String key) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Timer key cannot be null or empty."
+            );
+        }
         if (!startValuesMs.containsKey(key)) {
             throw new IllegalStateException(
                 MessageFormatter.format("The timer key {} does not exist in this instance of {}", key, getClass().toString()).getMessage()

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
@@ -106,6 +106,11 @@ class TimerManager {
      * @return clock instance
      */
     private Clock getClock() {
+        if (this.clock == null) {
+            throw new IllegalStateException(
+                "Clock instance is null, you can't track elapsed time without a clock."
+            );
+        }
         return this.clock;
     }
 
@@ -115,6 +120,11 @@ class TimerManager {
      * @param clock clock instance for testing
      */
     void setClock(final Clock clock) {
+        if (clock == null) {
+            throw new IllegalArgumentException(
+                "Clock instance cannot be null."
+            );
+        }
         this.clock = clock;
     }
 }

--- a/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/metrics/TimerManager.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.metrics;
+
+import org.slf4j.helpers.MessageFormatter;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages start times by key and returns deltas on stop calls for the same key.
+ */
+class TimerManager {
+
+    /**
+     * Keyed start values in millis.
+     */
+    private final Map<String, Long> startValuesMs = new ConcurrentHashMap<>();
+
+    /**
+     * Clock instance, normally a UTC clock but can be overridden for testing.
+     */
+    private Clock clock = Clock.systemUTC();
+
+    /**
+     * Manages start times by key and returns deltas on stop calls for the same key.
+     */
+    TimerManager() {
+    }
+
+    /**
+     * Start a timer based upon a provided key.
+     *
+     * Defaults start time to right now.
+     *
+     * @param key key for timer
+     */
+    void start(final String key) {
+        start(key, getClock().millis());
+    }
+
+    /**
+     * Start a timer based upon a provided key with a specified start time.
+     *
+     * Most likely you don't need this method and should use the one that defaults to right now.
+     *
+     * @param key key for timer
+     * @param startMs time in millis to set as the start
+     */
+    void start(final String key, final long startMs) {
+        if (startValuesMs.containsKey(key)) {
+            throw new IllegalStateException(
+                MessageFormatter.format("The timer key {} already exists in this instances of {}", key, getClass()).getMessage()
+            );
+        }
+
+        startValuesMs.put(key, startMs);
+    }
+
+    /**
+     * Stop a timer based upon a provided key.
+     *
+     * @param key key for timer
+     * @return time elapsed in millis
+     */
+    long stop(final String key) {
+        if (!startValuesMs.containsKey(key)) {
+            throw new IllegalStateException(
+                MessageFormatter.format("The timer key {} does not exist in this instance of {}", key, getClass().toString()).getMessage()
+            );
+        }
+
+        // This gets the value and then removes it, so we could in theory start this key again with a fresh timer
+        final long startTimeMs = startValuesMs.remove(key);
+        final long stopTimeMs = getClock().millis();
+
+        return stopTimeMs - startTimeMs;
+    }
+
+    /**
+     * Get clock instance.
+     * @return clock instance
+     */
+    private Clock getClock() {
+        return this.clock;
+    }
+
+    /**
+     * Override the manager's clock instance, this should only be done in tests.
+     *
+     * @param clock clock instance for testing
+     */
+    void setClock(final Clock clock) {
+        this.clock = clock;
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilderTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilderTest.java
@@ -94,4 +94,24 @@ class KeyBuilderTest {
             )
         );
     }
+
+    /**
+     * Test that a {@link KeyBuilder} with the wrong number of parameters works, but leaves the trailing placeholder.
+     */
+    @Test
+    void testWithMissingParameter() {
+        final String metricName = "custom_metric.{}.{}";
+        final MetricDefinition metricDefinition = new CustomMetric(metricName);
+        final String param1 = "foo";
+
+        final KeyBuilder keyBuilder = new KeyBuilder(null);
+
+        assertThat(
+            "Metric with parameters are formatted properly",
+            metricName.substring(0, metricName.length() - 6) + "." + param1 + ".{}",
+            equalTo(
+                keyBuilder.build(metricDefinition, new String[]{ param1 })
+            )
+        );
+    }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilderTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/metrics/KeyBuilderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test that {@link KeyBuilder} properly formats {@link MetricDefinition} objects into Strings.
+ */
+class KeyBuilderTest {
+
+    /**
+     * Test that a {@link KeyBuilder} with a prefix is prepended with that prefix.
+     */
+    @Test
+    void testWithPrefix() {
+        final String prefix = "prefix";
+        final String metricName = "custom_metric";
+        final MetricDefinition metricDefinition = new CustomMetric(metricName);
+
+        final KeyBuilder keyBuilder = new KeyBuilder(prefix);
+
+        assertThat(
+            "Prefix is properly placed before the metric name",
+            prefix + "." + metricName,
+            equalTo(
+                keyBuilder.build(metricDefinition, new Object[0])
+            )
+        );
+    }
+
+    /**
+     * Test that a {@link KeyBuilder} without a prefix is formatted correctly.
+     */
+    @Test
+    void testWithOutPrefix() {
+        final String metricName = "custom_metric";
+        final MetricDefinition metricDefinition = new CustomMetric(metricName);
+
+        final KeyBuilder keyBuilder = new KeyBuilder(null);
+
+        assertThat(
+            "Metric without a prefix comes out correctly",
+            metricName,
+            equalTo(
+                keyBuilder.build(metricDefinition, new Object[0])
+            )
+        );
+    }
+
+    /**
+     * Test that a {@link KeyBuilder} with parameters have them properly formatted.
+     */
+    @Test
+    void testWithParameters() {
+        final String metricName = "custom_metric.{}.{}";
+        final MetricDefinition metricDefinition = new CustomMetric(metricName);
+        final String param1 = "foo";
+        final String param2 = "bar";
+
+        final KeyBuilder keyBuilder = new KeyBuilder(null);
+
+        assertThat(
+            "Metric with parameters are formatted properly",
+            metricName.substring(0, metricName.length() - 6) + "." + param1 + "." + param2,
+            equalTo(
+                keyBuilder.build(metricDefinition, new String[]{ param1, param2 })
+            )
+        );
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/metrics/TimerManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/metrics/TimerManagerTest.java
@@ -106,4 +106,44 @@ class TimerManagerTest {
             timerManager.stop(timerKey)
         );
     }
+
+    /**
+     * Test that starting a timer with a null key throws an exception.
+     */
+    @Test
+    void testStartingNullKey() {
+        final String timerKey = null;
+
+        final TimerManager timerManager = new TimerManager();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+            timerManager.start(timerKey)
+        );
+    }
+
+    /**
+     * Test that stopping a timer with a null key throws an exception.
+     */
+    @Test
+    void testStoppingNullKey() {
+        final String timerKey = null;
+
+        final TimerManager timerManager = new TimerManager();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+            timerManager.start(timerKey)
+        );
+    }
+
+    /**
+     * Test that setting a null clock throws an exception.
+     */
+    @Test
+    void testSettingNullClock() {
+        final TimerManager timerManager = new TimerManager();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+            timerManager.setClock(null)
+        );
+    }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/metrics/TimerManagerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/metrics/TimerManagerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic.metrics;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Test that {@link TimerManager} tracks elapsed time correctly.
+ */
+class TimerManagerTest {
+
+    private static final long FIXED_TIME_MS = 100000L;
+    private static final Instant FIXED_TIME_INSTANT = Instant.ofEpochMilli(FIXED_TIME_MS);
+
+    /**
+     * Test that starting and stopping a timer records the proper amount of elapsed time.
+     */
+    @Test
+    void testRecordTime() {
+        // Number of millis we expect to skip before capturing our stop point
+        final long skipMs = 1000;
+        final String timerKey = "timer";
+
+        final TimerManager timerManager = new TimerManager();
+        // Set our internal clock to a fixed time, this will effectively be "now"
+        timerManager.setClock(
+            Clock.fixed(FIXED_TIME_INSTANT, ZoneOffset.UTC)
+        );
+        // At this point we should have captured the above fixed time for timerKey
+        timerManager.start(timerKey);
+
+        // Advance our internal clock by the skip amount
+        timerManager.setClock(
+            Clock.fixed(Instant.ofEpochMilli(FIXED_TIME_MS + skipMs), ZoneOffset.UTC)
+        );
+
+        final long elapsedMs = timerManager.stop(timerKey);
+
+        assertThat(
+            "Ms elapsed in the timer manager matches our skip amount",
+            skipMs,
+            equalTo(elapsedMs)
+        );
+
+        // Start the timer again, which should work because once things are stopped the key is removed, basically we should be able to
+        // start a timer with the same key after it's been stopped.
+        timerManager.start(timerKey);
+    }
+
+    /**
+     * Test that attempting to start the same timer twice throws an exception.
+     */
+    @Test
+    void testStartingTimerTwice() {
+        final String timerKey = "timer";
+
+        final TimerManager timerManager = new TimerManager();
+        timerManager.start(timerKey);
+
+        Assertions.assertThrows(IllegalStateException.class, () ->
+            timerManager.start(timerKey)
+        );
+    }
+
+    /**
+     * Test that stopping a timer that hasn't been started throws an exception.
+     */
+    @Test
+    void testStoppingUnstartedTimer() {
+        final String timerKey = "timer";
+
+        final TimerManager timerManager = new TimerManager();
+
+        Assertions.assertThrows(IllegalStateException.class, () ->
+            timerManager.stop(timerKey)
+        );
+    }
+}


### PR DESCRIPTION
First part in my work on #117, this takes several bits of code that are reused between `StormRecorder` and `LogRecorder` and breaks them out so that they can be used in a forthcoming `DropwizardRecorder` implementation.