### PR TITLE
Zookeeper reference implementation cleanup

### DIFF
--- a/src/main/java/com/salesforce/storm/spout/dynamic/JSON.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/JSON.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.salesforce.storm.spout.sideline.persistence.FilterChainStepTypeAdapterFactory;
+
+/**
+ * Thin wrapper around JSON parsing.
+ *
+ * Intended to hide the particular JSON implementation of the day.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class JSON {
+
+    /**
+     * JSON parser.
+     *
+     * Includes a special handler for serialized FilterChainSteps, which we hope to now always have to handle this way.
+     */
+    private static Gson gson = new GsonBuilder()
+        .setDateFormat("yyyy-MM-dd HH:mm:ss")
+        .registerTypeAdapterFactory(new FilterChainStepTypeAdapterFactory())
+        .create();
+
+    /**
+     * Convert an object to a string of JSON.
+     * @param value object to be converted.
+     * @return string of JSON.
+     */
+    public static String to(final Object value) {
+        return gson.toJson(value);
+    }
+
+    /**
+     * Convert a string of JSON to an object.
+     * @param value string of JSON to be converted.
+     * @param clazz class of object to convert the JSON to.
+     * @param <T> type to be used for returns.
+     * @return object converted from JSON.
+     */
+    public static <T> T from(final String value, final Class<T> clazz) {
+        return gson.fromJson(value, clazz);
+    }
+}

--- a/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/Tools.java
@@ -44,12 +44,11 @@ public class Tools {
      * @param sourceMap map we want to shallow clone and make immutable.
      * @param <K> key of the map.
      * @param <V> value of the map.
-     * @return sshallow cloned map that is immutable.
+     * @return shallow cloned map that is immutable.
      */
     public static <K,V> Map<K,V> immutableCopy(Map<K,V> sourceMap) {
         // Create a new map and add all entries from the source map
-        Map<K,V> copy = new HashMap<>();
-        copy.putAll(sourceMap);
+        Map<K, V> copy = new HashMap<>(sourceMap);
 
         // Wrap it in an unmodifiable map.
         return Collections.unmodifiableMap(copy);

--- a/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelper.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelper.java
@@ -25,8 +25,7 @@
 
 package com.salesforce.storm.spout.dynamic.persistence.zookeeper;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.salesforce.storm.spout.dynamic.JSON;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.zookeeper.CreateMode;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -54,29 +52,11 @@ public class CuratorHelper {
     private CuratorFramework curator;
 
     /**
-     * JSON parser.
-     */
-    private final Gson gson;
-
-    /**
      * Helper methods for common tasks when working with Curator.
      * @param curator curator instance.
      */
     public CuratorHelper(final CuratorFramework curator) {
-        this(
-            curator,
-            new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create()
-        );
-    }
-
-    /**
-     * Helper methods for common tasks when working with Curator.
-     * @param curator curator instance.
-     * @param gson JSON parser instance.
-     */
-    public CuratorHelper(final CuratorFramework curator, Gson gson) {
         this.curator = curator;
-        this.gson = gson;
     }
 
     /**
@@ -86,20 +66,7 @@ public class CuratorHelper {
      */
     public void writeJson(final String path, final Object data) {
         logger.debug("Zookeeper Writing {} the data {}", path, data.toString());
-        writeBytes(path, gson.toJson(data).getBytes(StandardCharsets.UTF_8));
-    }
-
-    /**
-     * Read data from Zookeeper that has been stored as JSON.
-     *
-     * This method will return a HashMap from the JSON.  You should consider using {@link #readJson(String, Class)} instead as it
-     * will deserialize the JSON to a concrete class.
-     *
-     * @param path node containing JSON to read from.
-     * @return map representing the JSON stored within the zookeeper node.
-     */
-    public HashMap readJson(final String path) {
-        return readJson(path, HashMap.class);
+        writeBytes(path, JSON.to(data).getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -118,7 +85,7 @@ public class CuratorHelper {
             if (bytes == null) {
                 return null;
             }
-            return gson.fromJson(new String(bytes, StandardCharsets.UTF_8), clazz);
+            return JSON.from(new String(bytes, StandardCharsets.UTF_8), clazz);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/persistence/ZookeeperPersistenceAdapter.java
@@ -27,7 +27,6 @@ package com.salesforce.storm.spout.sideline.persistence;
 
 import com.google.common.base.Preconditions;
 import com.salesforce.storm.spout.dynamic.ConsumerPartition;
-import com.google.gson.GsonBuilder;
 import com.salesforce.storm.spout.dynamic.Tools;
 import com.salesforce.storm.spout.dynamic.config.SpoutConfig;
 import com.salesforce.storm.spout.dynamic.persistence.zookeeper.CuratorFactory;
@@ -103,13 +102,7 @@ public class ZookeeperPersistenceAdapter implements PersistenceAdapter {
             SidelineSpout.class.getSimpleName() + ":" + getClass().getSimpleName()
         );
 
-        this.curatorHelper = new CuratorHelper(
-            curator,
-            new GsonBuilder()
-                .setDateFormat("yyyy-MM-dd HH:mm:ss")
-                .registerTypeAdapterFactory(new FilterChainStepTypeAdapterFactory())
-                .create()
-        );
+        this.curatorHelper = new CuratorHelper(curator);
     }
 
     /**

--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
@@ -47,7 +47,7 @@ public class Config {
         description = "Class name for the class of the FilterChainStepBuilder instance.",
         type = String.class
     )
-    public static final String FILTER_CHAIN_STEP_BUILDER_CLASS = "sideline.zookeeper_watch_trigger.filter_chain_step_builder_class";
+    public static final String FILTER_CHAIN_STEP_BUILDER_CLASS = PREFIX + "filter_chain_step_builder_class";
 
     /**
      * (List[String]) Holds a list of Zookeeper server Hostnames + Ports in the following format:
@@ -58,17 +58,20 @@ public class Config {
         + "[\"zkhost1:2181\", \"zkhost2:2181\", ...]",
         type = List.class
     )
-    public static final String ZK_SERVERS = "sideline.zookeeper_watch_trigger.servers";
+    public static final String ZK_SERVERS = PREFIX + "servers";
 
     /**
-     * (List[String]) Defines the root paths to watch for events under.
-     * Example: "/sideline-trigger"
+     * (String) Defines the root path to watch for events under.
+     * It is recommended that you scope your root to your topology and kafka topic.
+     * Example: /sideline-trigger/my-topology/my-topic
      */
     @ConfigDocumentation(
-        description = "Defines the root paths to watch for events under. Example: \"/sideline-trigger\"",
-        type = List.class
+        description = "Defines the root path to watch for events under. "
+            + "It is recommended that you scope your root to your topology and kafka topic."
+            + "Example: \"/sideline-trigger/my-topology/my-topic\"",
+        type = String.class
     )
-    public static final String ZK_ROOTS = "sideline.zookeeper_watch_trigger.roots";
+    public static final String ZK_ROOT = PREFIX + "roots";
 
     /**
      * (Integer) Zookeeper session timeout.
@@ -77,7 +80,7 @@ public class Config {
         description = "Zookeeper session timeout.",
         type = Integer.class
     )
-    public static final String ZK_SESSION_TIMEOUT = "sideline.zookeeper_watch_trigger.session_timeout";
+    public static final String ZK_SESSION_TIMEOUT = PREFIX + "session_timeout";
 
     /**
      * (Integer) Zookeeper connection timeout.
@@ -86,7 +89,7 @@ public class Config {
         description = "Zookeeper connection timeout.",
         type = Integer.class
     )
-    public static final String ZK_CONNECTION_TIMEOUT = "sideline.zookeeper_watch_trigger.connection_timeout";
+    public static final String ZK_CONNECTION_TIMEOUT = PREFIX + "connection_timeout";
 
     /**
      * (Integer) Zookeeper retry attempts.
@@ -95,7 +98,7 @@ public class Config {
         description = "Zookeeper retry attempts.",
         type = Integer.class
     )
-    public static final String ZK_RETRY_ATTEMPTS = "sideline.zookeeper_watch_trigger.retry_attempts";
+    public static final String ZK_RETRY_ATTEMPTS = PREFIX + "retry_attempts";
 
     /**
      * (Integer) Zookeeper retry interval.
@@ -104,5 +107,5 @@ public class Config {
         description = "Zookeeper retry interval.",
         type = Integer.class
     )
-    public static final String ZK_RETRY_INTERVAL = "sideline.zookeeper_watch_trigger.retry_interval";
+    public static final String ZK_RETRY_INTERVAL = PREFIX + "retry_interval";
 }

--- a/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/trigger/SidelineType.java
@@ -46,5 +46,27 @@ public enum SidelineType {
      * cease to run whenever it reached that {@link com.salesforce.storm.spout.dynamic.consumer.ConsumerState}. The filter is also
      * removed from the firehose, so that future record's are processed in real time.
      */
-    RESOLVE,
+    RESOLVE;
+
+    /**
+     * Get a {@link SidelineType} from a provided string.
+     * @param value string that maps to a specific sideline type.
+     * @return sideline type from the provided string.
+     */
+    public static SidelineType fromValue(final String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Provided value cannot be null.");
+        }
+
+        switch (value.toLowerCase()) {
+            case "start":
+                return SidelineType.START;
+            case "resume":
+                return SidelineType.RESUME;
+            case "resolve":
+                return SidelineType.RESOLVE;
+            default:
+                throw new IllegalArgumentException("Provided \"" + value + "\" is not a valid sideline type.");
+        }
+    }
 }

--- a/src/test/java/com/salesforce/storm/spout/dynamic/JSONTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/JSONTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.dynamic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that the JSON abstraction converts to and from JSON correctly.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+class JSONTest {
+
+    // Why the heck am I double wrapping the map? Because GSON can't handle inner classes...
+    private final Map<String, Object> jsonMap = new HashMap<>(new HashMap<String, Object>() {
+        {
+            put("key1", "value1");
+            put("key2", 2.0);
+            put("key3", true);
+        }
+    });
+
+    // Note GSON favors doubles, so if I gave it just "2" I'd still get 2.0 when it converts to JSON
+    private final String json = "{\"key1\":\"value1\",\"key2\":2.0,\"key3\":true}";
+
+    /**
+     * Test that given a Map we get a valid string of JSON back.
+     */
+    @Test
+    void testTo() {
+        assertEquals(
+            json,
+            JSON.to(jsonMap)
+        );
+    }
+
+    /**
+     * Test that given a string of JSON we get a valid HashMap back.
+     */
+    @Test
+    void testFrom() {
+        assertEquals(
+            jsonMap,
+            JSON.from(json, HashMap.class)
+        );
+    }
+}

--- a/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/persistence/zookeeper/CuratorHelperTest.java
@@ -104,7 +104,7 @@ public class CuratorHelperTest {
 
             // Read
             @SuppressWarnings("unchecked")
-            final Map<String, Object> resultMap = curatorHelper.readJson(path);
+            final Map<String, Object> resultMap = curatorHelper.readJson(path, HashMap.class);
 
             // Validate
             assertNotNull(resultMap, "Not null result");

--- a/src/test/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTriggerTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/ZookeeperWatchTriggerTest.java
@@ -84,7 +84,7 @@ public class ZookeeperWatchTriggerTest {
         final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
         config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, consumerId);
         config.put(Config.ZK_SERVERS, Collections.singletonList(getZookeeperConnectionString()));
-        config.put(Config.ZK_ROOTS, Collections.singletonList(zkRoot));
+        config.put(Config.ZK_ROOT, zkRoot);
         config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
         config.put(
             SpoutConfig.PERSISTENCE_ADAPTER_CLASS,
@@ -202,7 +202,7 @@ public class ZookeeperWatchTriggerTest {
         final Map<String, Object> config = SpoutConfig.setDefaults(new HashMap<>());
         config.put(SpoutConfig.VIRTUAL_SPOUT_ID_PREFIX, consumerId);
         config.put(Config.ZK_SERVERS, Collections.singletonList(getZookeeperConnectionString()));
-        config.put(Config.ZK_ROOTS, Collections.singletonList(zkRoot));
+        config.put(Config.ZK_ROOT, zkRoot);
         config.put(SpoutConfig.CONSUMER_CLASS, MockConsumer.class.getName());
         config.put(
             SpoutConfig.PERSISTENCE_ADAPTER_CLASS,

--- a/src/test/java/com/salesforce/storm/spout/sideline/trigger/SidelineTypeTest.java
+++ b/src/test/java/com/salesforce/storm/spout/sideline/trigger/SidelineTypeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, 2018, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.storm.spout.sideline.trigger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test that helper methods on {@link SidelineType} work.
+ */
+class SidelineTypeTest {
+
+    /**
+     * Test that {@link SidelineType#fromValue(String)} handles strings to type in a case insensitive manner.
+     */
+    @Test
+    void testFromValue() {
+        assertEquals(
+            SidelineType.START,
+            SidelineType.fromValue("start")
+        );
+
+        assertEquals(
+            SidelineType.START,
+            SidelineType.fromValue("START")
+        );
+
+        assertEquals(
+            SidelineType.START,
+            SidelineType.fromValue("sTarT")
+        );
+
+        assertEquals(
+            SidelineType.RESOLVE,
+            SidelineType.fromValue("resolve")
+        );
+
+        assertEquals(
+            SidelineType.RESUME,
+            SidelineType.fromValue("resume")
+        );
+    }
+
+    /**
+     * Test that {@link SidelineType#fromValue(String)} throws an exception for strings that don't map to types.
+     */
+    @Test
+    void testFromUndefineValue() {
+        assertThrows(IllegalArgumentException.class, () ->
+            SidelineType.fromValue("notRealSidelineType")
+        );
+    }
+
+    /**
+     * Test that {@link SidelineType#fromValue(String)} throws an exception for null.
+     */
+    @Test
+    void testFromNull() {
+        assertThrows(IllegalArgumentException.class, () ->
+            SidelineType.fromValue(null)
+        );
+    }
+}


### PR DESCRIPTION
Most of this is simple cleanup. There is one notable change though, in the original reference implementation for 0.10 the zookeeper watch supports multiple roots. I don't recall what the reason for this complexity was, probably accounting for the weird way we tried handling global sidelines in the implementation that preceded this. I am confident that there's a better/cleaner way of doing that. I am just not sure that additional complexity is worth it.