### PR TITLE
Fix sideline zk configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk11
+  - openjdk11
 sudo: false
 cache:
   directories:

--- a/src/main/java/com/salesforce/storm/spout/dynamic/kafka/Consumer.java
+++ b/src/main/java/com/salesforce/storm/spout/dynamic/kafka/Consumer.java
@@ -455,8 +455,12 @@ public class Consumer implements com.salesforce.storm.spout.dynamic.consumer.Con
         // Get the current state
         final ConsumerState consumerState = partitionOffsetsManager.getCurrentState();
 
-        // Persist each partition offset
+        if (consumerState == null) {
+            logger.error("Attempting to flush state when the current state is null.");
+            return null;
+        }
 
+        // Persist each partition offset
         for (Map.Entry<ConsumerPartition, Long> entry : consumerState.entrySet()) {
             final ConsumerPartition consumerPartition = entry.getKey();
             final long lastFinishedOffset = entry.getValue();

--- a/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/config/SidelineConfig.java
@@ -39,13 +39,13 @@ import java.util.Map;
 public class SidelineConfig {
 
     /**
-     * (List|String) Defines one or more sideline trigger(s) (if any) to use.
+     * (String) Defines a sideline trigger (if any) to use.
      * Should be a fully qualified class path that implements thee SidelineTrigger interface.
      */
     @ConfigDocumentation(
         category = ConfigDocumentation.Category.SIDELINE,
-        description = "Defines one or more sideline trigger(s) (if any) to use. "
-        + "Should be a fully qualified class path that implements thee SidelineTrigger interface.",
+        description = "Defines a sideline trigger (if any) to use. "
+        + "Should be a fully qualified class path that implements the SidelineTrigger interface.",
         type = String.class
     )
     public static final String TRIGGER_CLASS = "sideline.trigger_class";

--- a/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
+++ b/src/main/java/com/salesforce/storm/spout/sideline/recipes/trigger/zookeeper/Config.java
@@ -71,7 +71,7 @@ public class Config {
             + "Example: \"/sideline-trigger/my-topology/my-topic\"",
         type = String.class
     )
-    public static final String ZK_ROOT = PREFIX + "roots";
+    public static final String ZK_ROOT = PREFIX + "root";
 
     /**
      * (Integer) Zookeeper session timeout.

--- a/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
+++ b/src/test/java/com/salesforce/storm/spout/dynamic/VirtualSpoutTest.java
@@ -49,6 +49,7 @@ import com.salesforce.storm.spout.dynamic.persistence.PersistenceAdapter;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Values;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -78,6 +79,14 @@ import static org.mockito.Mockito.when;
  * Test that a {@link VirtualSpout} properly acks, fails and emits data from it's consumer.
  */
 public class VirtualSpoutTest {
+
+    /**
+     * Before each test reset the static on the MockConsumer.
+     */
+    @BeforeEach
+    void resetMockConsumerPartitions() {
+        MockConsumer.partitions = Arrays.asList(1);
+    }
 
     /**
      * Verify that constructor args get set appropriately.


### PR DESCRIPTION
The 'root' configuration only supports one root, this typo is a holdover from the old implementation where we supported a list of roots to watch.